### PR TITLE
Avoid `bytestring` >= 0.11 with GHC < 8.0

### DIFF
--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -207,7 +207,10 @@ library
     build-depends: bytestring < 0.10.4.0
                  , bytestring-builder
   else
-    build-depends: bytestring >= 0.10.4
+    if impl(ghc < 8.0)
+      build-depends: bytestring >= 0.10.4 && < 0.11
+    else
+      build-depends: bytestring >= 0.10.4 && < 0.12
 
   if impl(ghc < 8.0)
     build-depends: semigroups


### PR DESCRIPTION
In `bytestring` 0.11 the `PS` constructor becomes a pattern synonym, only
available with GHC >= 8.0.  Since this package depends on `bytestring`
internals, and in particular the `PS` constructor, with GHC < 8.0 it must
stick to older bytestring releases.

With GHC >= 8.0, this package will be compatible with the imminent
`bytestring` 0.11, so the dependency ceiling is for now set to < 0.12.