### PR TITLE
Lints and Reformatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@
 
 - An incorrect comment about `Handle`s being automatically closed upon EOF with
   `hGetContents` and `hGetContentsN`. [#9]
+- A critical bug in `group` and `groupBy` that would crash code when reading
+  enough bytes. [#22]
 
 [#9]: https://github.com/haskell-streaming/streaming-bytestring/issues/9
 [#18]: https://github.com/haskell-streaming/streaming-bytestring/pull/18
+[#22]: https://github.com/haskell-streaming/streaming-bytestring/pull/22
 
 ## 0.1.6
 

--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -1204,7 +1204,7 @@ group = go
       | otherwise       = Step $ to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
 
     to acc !_ (Empty r) = revNonEmptyChunks acc (Empty (Return r))
-    to _ _ (Go _) = error "Impossible case"
+    to acc !w (Go m) = Go $ to acc w <$> m
     to acc !w (Chunk c cs) = case findIndexOrEnd (/= w) c of
       0 -> revNonEmptyChunks acc (Empty (go (Chunk c cs)))
       n | n == S.length c -> to (S.unsafeTake n c : acc) w cs
@@ -1222,7 +1222,7 @@ groupBy rel = go
       | otherwise       = Step $ to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
 
     to acc !_ (Empty r) = revNonEmptyChunks acc (Empty (Return r))
-    to _ _ (Go _) = error "Impossible case"
+    to acc !w (Go m) = Go $ to acc w <$> m
     to acc !w (Chunk c cs) = case findIndexOrEnd (not . rel w) c of
       0 -> revNonEmptyChunks acc (Empty (go (Chunk c cs)))
       n | n == S.length c  -> to (S.unsafeTake n c : acc) w cs

--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -222,6 +222,7 @@ import           Foreign.Storable
 import           System.IO (Handle, IOMode(..), hClose, openBinaryFile)
 import qualified System.IO as IO (stdin, stdout)
 import           System.IO.Error (illegalOperationErrorType, mkIOError)
+import           System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- | /O(n)/ Concatenate a stream of byte streams.
 concat :: Monad m => Stream (ByteString m) m r -> ByteString m r
@@ -1675,7 +1676,7 @@ revChunks cs r = L.foldl' (flip Chunk) (Empty r) cs
 -- of the string if no element is found, rather than Nothing.
 findIndexOrEnd :: (Word8 -> Bool) -> P.ByteString -> Int
 findIndexOrEnd k (S.PS x s l) =
-    inlinePerformIO $
+    unsafeDupablePerformIO $
       withForeignPtr x $ \f -> go (f `plusPtr` s) 0
   where
     go !ptr !n | n >= l    = return l

--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -200,11 +200,11 @@ import           Prelude hiding
 import qualified Prelude
 
 import qualified Data.ByteString as P (ByteString)
-import qualified Data.ByteString as S
+import qualified Data.ByteString as B
 import           Data.ByteString.Builder.Internal hiding
     (append, defaultChunkSize, empty, hPut)
-import qualified Data.ByteString.Internal as S
-import qualified Data.ByteString.Unsafe as S
+import qualified Data.ByteString.Internal as B
+import qualified Data.ByteString.Unsafe as B
 
 import           Data.ByteString.Streaming.Internal
 import           Streaming hiding (concats, distribute, unfold)
@@ -222,7 +222,6 @@ import           Foreign.Storable
 import           System.IO (Handle, IOMode(..), hClose, openBinaryFile)
 import qualified System.IO as IO (stdin, stdout)
 import           System.IO.Error (illegalOperationErrorType, mkIOError)
-import           System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- | /O(n)/ Concatenate a stream of byte streams.
 concat :: Monad m => Stream (ByteString m) m r -> ByteString m r
@@ -273,7 +272,7 @@ empty = Empty ()
 {-| /O(1)/ Yield a 'Word8' as a minimal 'ByteString'
 -}
 singleton :: Monad m => Word8 -> ByteString m ()
-singleton w = Chunk (S.singleton w)  (Empty ())
+singleton w = Chunk (B.singleton w)  (Empty ())
 {-# INLINE singleton #-}
 
 {-| /O(n)/ Convert a monadic stream of individual 'Word8's into a packed byte stream.
@@ -311,7 +310,7 @@ toChunks bs =
 {-| /O(1)/ yield a strict 'ByteString' chunk.
 -}
 fromStrict :: P.ByteString -> ByteString m ()
-fromStrict bs | S.null bs = Empty ()
+fromStrict bs | B.null bs = Empty ()
               | otherwise = Chunk bs  (Empty ())
 {-# INLINE fromStrict #-}
 
@@ -321,8 +320,8 @@ fromStrict bs | S.null bs = Empty ()
   ByteString into memory and then copies all the data. If possible, try to
   avoid converting back and forth between streaming and strict bytestrings.
 -}
-toStrict_ :: Monad m => ByteString m () -> m (S.ByteString)
-toStrict_ = liftM S.concat . SP.toList_ . toChunks
+toStrict_ :: Monad m => ByteString m () -> m (B.ByteString)
+toStrict_ = liftM B.concat . SP.toList_ . toChunks
 {-# INLINE toStrict_ #-}
 
 
@@ -335,10 +334,10 @@ toStrict_ = liftM S.concat . SP.toList_ . toChunks
    It is subject to all the objections one makes to Data.ByteString.Lazy 'toStrict';
    all of these are devastating.
 -}
-toStrict :: Monad m => ByteString m r -> m (Of S.ByteString r)
+toStrict :: Monad m => ByteString m r -> m (Of B.ByteString r)
 toStrict bs = do
   (bss :> r) <- SP.toList (toChunks bs)
-  return $ (S.concat bss :> r)
+  return $ (B.concat bss :> r)
 {-# INLINE toStrict #-}
 
 {- |/O(c)/ Transmute a pseudo-pure lazy bytestring to its representation
@@ -420,7 +419,7 @@ False
 null :: Monad m => ByteString m r -> m (Of Bool r)
 null (Empty r)  = return (True :> r)
 null (Go m)     = m >>= null
-null (Chunk bs rest) = if S.null bs
+null (Chunk bs rest) = if B.null bs
    then null rest
    else do
      r <- SP.effects (toChunks rest)
@@ -440,7 +439,7 @@ Q.null $ Q.take 0 Q.stdin :: MonadIO m => m Bool
 null_ :: Monad m => ByteString m r -> m Bool
 null_ (Empty _)      = return True
 null_ (Go m)         = m >>= null_
-null_ (Chunk bs rest) = if S.null bs
+null_ (Chunk bs rest) = if B.null bs
   then null_ rest
   else return False
 {-# INLINABLE null_ #-}
@@ -449,7 +448,7 @@ null_ (Chunk bs rest) = if S.null bs
 testNull :: Monad m => ByteString m r -> m (Of Bool (ByteString m r))
 testNull (Empty r)  = return (True :> Empty r)
 testNull (Go m)     = m >>= testNull
-testNull p@(Chunk bs rest) = if S.null bs
+testNull p@(Chunk bs rest) = if B.null bs
    then testNull rest
    else return (False :> p)
 {-# INLINABLE testNull #-}
@@ -496,14 +495,14 @@ Q.effects . Q.concat
 nulls :: Monad m => ByteString m r -> m (Sum (ByteString m) (ByteString m) r)
 nulls (Empty r)  = return (InR (return r))
 nulls (Go m)     = m >>= nulls
-nulls (Chunk bs rest) = if S.null bs
+nulls (Chunk bs rest) = if B.null bs
    then nulls rest
    else return (InL (Chunk bs rest))
 {-# INLINABLE nulls #-}
 
 
 length_ :: Monad m => ByteString m r -> m Int
-length_  = liftM (\(n:> _) -> n) . foldlChunks (\n c -> n + fromIntegral (S.length c)) 0
+length_  = liftM (\(n:> _) -> n) . foldlChunks (\n c -> n + fromIntegral (B.length c)) 0
 {-# INLINE length_ #-}
 
 {-| /O(n\/c)/ 'length' returns the length of a byte stream as an 'Int'
@@ -517,7 +516,7 @@ length_  = liftM (\(n:> _) -> n) . foldlChunks (\n c -> n + fromIntegral (S.leng
 4
 -}
 length :: Monad m => ByteString m r -> m (Of Int r)
-length cs = foldlChunks (\n c -> n + fromIntegral (S.length c)) 0 cs
+length cs = foldlChunks (\n c -> n + fromIntegral (B.length c)) 0 cs
 {-# INLINE length #-}
 
 -- infixr 5 `cons` -- , `cons'` --same as list (:)
@@ -526,7 +525,7 @@ length cs = foldlChunks (\n c -> n + fromIntegral (S.length c)) 0 cs
 -- | /O(1)/ 'cons' is analogous to '(:)' for lists.
 --
 cons :: Monad m => Word8 -> ByteString m r -> ByteString m r
-cons c cs = Chunk (S.singleton c) cs
+cons c cs = Chunk (B.singleton c) cs
 {-# INLINE cons #-}
 
 -- | /O(1)/ Unlike 'cons', 'cons\'' is
@@ -543,8 +542,8 @@ cons c cs = Chunk (S.singleton c) cs
 -- infinite byte streams.
 --
 cons' :: Word8 -> ByteString m r -> ByteString m r
-cons' w (Chunk c cs) | S.length c < 16 = Chunk (S.cons w c) cs
-cons' w cs           = Chunk (S.singleton w) cs
+cons' w (Chunk c cs) | B.length c < 16 = Chunk (B.cons w c) cs
+cons' w cs           = Chunk (B.singleton w) cs
 {-# INLINE cons' #-}
 -- --
 -- | /O(n\/c)/ Append a byte to the end of a 'ByteString'
@@ -558,16 +557,16 @@ snoc cs w = do    -- cs <* singleton w
 -- | /O(1)/ Extract the first element of a 'ByteString', which must be non-empty.
 head_ :: Monad m => ByteString m r -> m Word8
 head_ (Empty _)   = error "head"
-head_ (Chunk c bs) = if S.null c
+head_ (Chunk c bs) = if B.null c
                         then head_ bs
-                        else return $ S.unsafeHead c
+                        else return $ B.unsafeHead c
 head_ (Go m)      = m >>= head_
 {-# INLINABLE head_ #-}
 
 -- | /O(c)/ Extract the first element of a 'ByteString', which must be non-empty.
 head :: Monad m => ByteString m r -> m (Of (Maybe Word8) r)
 head (Empty r)  = return (Nothing :> r)
-head (Chunk c rest) = case S.uncons c of
+head (Chunk c rest) = case B.uncons c of
   Nothing -> head rest
   Just (w,_) -> do
     r <- SP.effects $ toChunks rest
@@ -580,10 +579,10 @@ head (Go m)      = m >>= head
 uncons :: Monad m => ByteString m r -> m (Maybe (Word8, ByteString m r))
 uncons (Empty _) = return Nothing
 uncons (Chunk c cs)
-    = return $ Just (S.unsafeHead c
-                     , if S.length c == 1
+    = return $ Just (B.unsafeHead c
+                     , if B.length c == 1
                          then cs
-                         else Chunk (S.unsafeTail c) cs )
+                         else Chunk (B.unsafeTail c) cs )
 uncons (Go m) = m >>= uncons
 {-# INLINABLE uncons #-}
 --
@@ -592,26 +591,26 @@ uncons (Go m) = m >>= uncons
 nextByte :: Monad m => ByteString m r -> m (Either r (Word8, ByteString m r))
 nextByte (Empty r) = return (Left r)
 nextByte (Chunk c cs)
-    = if S.null c
+    = if B.null c
         then nextByte cs
-        else return $ Right (S.unsafeHead c
-                     , if S.length c == 1
+        else return $ Right (B.unsafeHead c
+                     , if B.length c == 1
                          then cs
-                         else Chunk (S.unsafeTail c) cs )
+                         else Chunk (B.unsafeTail c) cs )
 nextByte (Go m) = m >>= nextByte
 {-# INLINABLE nextByte #-}
 
-unconsChunk :: Monad m => ByteString m r -> m (Maybe (S.ByteString, ByteString m r))
+unconsChunk :: Monad m => ByteString m r -> m (Maybe (B.ByteString, ByteString m r))
 unconsChunk = \bs -> case bs of
   Empty _    -> return Nothing
   Chunk c cs -> return (Just (c,cs))
   Go m       ->  m >>= unconsChunk
 {-# INLINABLE unconsChunk #-}
 
-nextChunk :: Monad m => ByteString m r -> m (Either r (S.ByteString, ByteString m r))
+nextChunk :: Monad m => ByteString m r -> m (Either r (B.ByteString, ByteString m r))
 nextChunk = \bs -> case bs of
   Empty r    -> return (Left r)
-  Chunk c cs -> if S.null c
+  Chunk c cs -> if B.null c
     then nextChunk cs
     else return (Right (c,cs))
   Go m       -> m >>= nextChunk
@@ -624,7 +623,7 @@ last_ (Empty _)      = error "Data.ByteString.Streaming.last: empty string"
 last_ (Go m)         = m >>= last_
 last_ (Chunk c0 cs0) = go c0 cs0
  where
-   go c (Empty _)    = if S.null c
+   go c (Empty _)    = if B.null c
        then error "Data.ByteString.Streaming.last: empty string"
        else return $ unsafeLast c
    go _ (Chunk c cs) = go c cs
@@ -643,9 +642,9 @@ last (Chunk c0 cs0) = go c0 cs0
 {-# INLINABLE last #-}
 
 
--- isPrefixOf :: Monad m => S.ByteString -> ByteString m r -> m (Sum (ByteString m) (ByteString m) r)
+-- isPrefixOf :: Monad m => B.ByteString -> ByteString m r -> m (Sum (ByteString m) (ByteString m) r)
 -- isPrefixOf bytes bs = do
---   let len = S.length bytes
+--   let len = B.length bytes
 --   (bytes' :> rest) <- toStrict $ splitAt (fromIntegral len) bs
 --   if bytes' == bytes
 --     then return $ InR $ chunk bytes' >> rest
@@ -654,8 +653,8 @@ last (Chunk c0 cs0) = go c0 cs0
 -- init :: ByteString -> ByteString
 -- init Empty          = errorEmptyStream "init"
 -- init (Chunk c0 cs0) = go c0 cs0
---   where go c Empty | S.length c == 1 = Empty
---                    | otherwise       = Chunk (S.unsafeInit c) Empty
+--   where go c Empty | B.length c == 1 = Empty
+--                    | otherwise       = Chunk (B.unsafeInit c) Empty
 --         go c (Chunk c' cs)           = Chunk c (go c' cs)
 --
 -- -- | /O(n\/c)/ Extract the 'init' and 'last' of a ByteString, returning Nothing
@@ -679,14 +678,14 @@ append xs ys = dematerialize xs (const ys) Chunk Go
 map :: Monad m => (Word8 -> Word8) -> ByteString m r -> ByteString m r
 map f z = dematerialize z
    Empty
-   (\bs x -> Chunk (S.map f bs) x)
+   (\bs x -> Chunk (B.map f bs) x)
    Go
 -- map f s = go s
 --     where
 --         go (Empty r)    = Empty r
 --         go (Chunk x xs) = Chunk y ys
 --             where
---                 y  = S.map f x
+--                 y  = B.map f x
 --                 ys = go xs
 --         go (Go mbs) = Go (liftM go mbs)
 {-# INLINE map #-}
@@ -695,7 +694,7 @@ map f z = dematerialize z
 -- reverse :: ByteString -> ByteString
 -- reverse cs0 = rev Empty cs0
 --   where rev a Empty        = a
---         rev a (Chunk c cs) = rev (Chunk (S.reverse c) a) cs
+--         rev a (Chunk c cs) = rev (Chunk (B.reverse c) a) cs
 -- {-# INLINE reverse #-}
 
 -- | The 'intersperse' function takes a 'Word8' and a 'ByteString' and
@@ -704,13 +703,13 @@ map f z = dematerialize z
 intersperse :: Monad m => Word8 -> ByteString m r -> ByteString m r
 intersperse _ (Empty r)    = Empty r
 intersperse w (Go m)       = Go (liftM (intersperse w) m)
-intersperse w (Chunk c cs) = Chunk (S.intersperse w c)
+intersperse w (Chunk c cs) = Chunk (B.intersperse w c)
                                    (dematerialize cs Empty (Chunk . intersperse') Go)
   where intersperse' :: P.ByteString -> P.ByteString
-        intersperse' (S.PS fp o l) =
-          S.unsafeCreate (2*l) $ \p' -> withForeignPtr fp $ \p -> do
+        intersperse' (B.PS fp o l) =
+          B.unsafeCreate (2*l) $ \p' -> withForeignPtr fp $ \p -> do
             poke p' w
-            S.c_intersperse (p' `plusPtr` 1) (p `plusPtr` o) (fromIntegral l) w
+            B.c_intersperse (p' `plusPtr` 1) (p `plusPtr` o) (fromIntegral l) w
 
 {-# INLINABLE intersperse #-}
 
@@ -721,7 +720,7 @@ intersperse w (Chunk c cs) = Chunk (S.intersperse w c)
 -- > foldr cons = id
 --
 foldr :: Monad m => (Word8 -> a -> a) -> a -> ByteString m () -> m a
-foldr k  = foldrChunks (flip (S.foldr k))
+foldr k  = foldrChunks (flip (B.foldr k))
 {-# INLINE foldr #-}
 
 -- -- ---------------------------------------------------------------------
@@ -733,7 +732,7 @@ fold :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteString m () -> m b
 fold step0 begin finish p0 = loop p0 begin
   where
     loop p !x = case p of
-        Chunk bs bss -> loop bss $! S.foldl' step0 x bs
+        Chunk bs bss -> loop bss $! B.foldl' step0 x bs
         Go    m      -> m >>= \p' -> loop p' x
         Empty _      -> return (finish x)
 {-# INLINABLE fold #-}
@@ -746,7 +745,7 @@ fold_ :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteString m r -> m (O
 fold_ step0 begin finish p0 = loop p0 begin
   where
     loop p !x = case p of
-        Chunk bs bss -> loop bss $! S.foldl' step0 x bs
+        Chunk bs bss -> loop bss $! B.foldl' step0 x bs
         Go    m      -> m >>= \p' -> loop p' x
         Empty r      -> return (finish x :> r)
 {-# INLINABLE fold_ #-}
@@ -758,20 +757,20 @@ fold_ step0 begin finish p0 = loop p0 begin
 -- -- argument, and thus must be applied to non-empty 'ByteStrings'.
 -- foldl1 :: (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 -- foldl1 _ Empty        = errorEmptyStream "foldl1"
--- foldl1 f (Chunk c cs) = foldl f (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+-- foldl1 f (Chunk c cs) = foldl f (B.unsafeHead c) (Chunk (B.unsafeTail c) cs)
 --
 -- -- | 'foldl1\'' is like 'foldl1', but strict in the accumulator.
 -- foldl1' :: (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 -- foldl1' _ Empty        = errorEmptyStream "foldl1'"
--- foldl1' f (Chunk c cs) = foldl' f (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+-- foldl1' f (Chunk c cs) = foldl' f (B.unsafeHead c) (Chunk (B.unsafeTail c) cs)
 --
 -- -- | 'foldr1' is a variant of 'foldr' that has no starting value argument,
 -- -- and thus must be applied to non-empty 'ByteString's
 -- foldr1 :: (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 -- foldr1 _ Empty          = errorEmptyStream "foldr1"
 -- foldr1 f (Chunk c0 cs0) = go c0 cs0
---   where go c Empty         = S.foldr1 f c
---         go c (Chunk c' cs) = S.foldr  f (go c' cs) c
+--   where go c Empty         = B.foldr1 f c
+--         go c (Chunk c' cs) = B.foldr  f (go c' cs) c
 --
 -- ---------------------------------------------------------------------
 -- Special folds
@@ -797,37 +796,37 @@ fold_ step0 begin finish p0 = loop p0 begin
 --     go (Chunk c cs) c' cs' = Chunk c (go cs c' cs')
 --
 --     to :: P.ByteString -> ByteString -> ByteString
---     to c cs | S.null c  = case cs of
+--     to c cs | B.null c  = case cs of
 --         Empty          -> Empty
 --         (Chunk c' cs') -> to c' cs'
---             | otherwise = go (f (S.unsafeHead c)) (S.unsafeTail c) cs
+--             | otherwise = go (f (B.unsafeHead c)) (B.unsafeTail c) cs
 --
 -- -- | /O(n)/ Applied to a predicate and a ByteString, 'any' determines if
 -- -- any element of the 'ByteString' satisfies the predicate.
 -- any :: (Word8 -> Bool) -> ByteString -> Bool
--- any f cs = foldrChunks (\c rest -> S.any f c || rest) False cs
+-- any f cs = foldrChunks (\c rest -> B.any f c || rest) False cs
 -- {-# INLINE any #-}
 -- -- todo fuse
 --
 -- -- | /O(n)/ Applied to a predicate and a 'ByteString', 'all' determines
 -- -- if all elements of the 'ByteString' satisfy the predicate.
 -- all :: (Word8 -> Bool) -> ByteString -> Bool
--- all f cs = foldrChunks (\c rest -> S.all f c && rest) True cs
+-- all f cs = foldrChunks (\c rest -> B.all f c && rest) True cs
 -- {-# INLINE all #-}
 -- -- todo fuse
 --
 -- -- | /O(n)/ 'maximum' returns the maximum value from a 'ByteString'
 -- maximum :: ByteString -> Word8
 -- maximum Empty        = errorEmptyStream "maximum"
--- maximum (Chunk c cs) = foldlChunks (\n c' -> n `max` S.maximum c')
---                                    (S.maximum c) cs
+-- maximum (Chunk c cs) = foldlChunks (\n c' -> n `max` B.maximum c')
+--                                    (B.maximum c) cs
 -- {-# INLINE maximum #-}
 --
 -- -- | /O(n)/ 'minimum' returns the minimum value from a 'ByteString'
 -- minimum :: ByteString -> Word8
 -- minimum Empty        = errorEmptyStream "minimum"
--- minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
---                                      (S.minimum c) cs
+-- minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` B.minimum c')
+--                                      (B.minimum c) cs
 -- {-# INLINE minimum #-}
 --
 -- -- | The 'mapAccumL' function behaves like a combination of 'map' and
@@ -839,7 +838,7 @@ fold_ step0 begin finish p0 = loop p0 begin
 --   where
 --     go s Empty        = (s, Empty)
 --     go s (Chunk c cs) = (s'', Chunk c' cs')
---         where (s',  c')  = S.mapAccumL f s c
+--         where (s',  c')  = B.mapAccumL f s c
 --               (s'', cs') = go s' cs
 --
 -- -- | The 'mapAccumR' function behaves like a combination of 'map' and
@@ -851,7 +850,7 @@ fold_ step0 begin finish p0 = loop p0 begin
 --   where
 --     go s Empty        = (s, Empty)
 --     go s (Chunk c cs) = (s'', Chunk c' cs')
---         where (s'', c') = S.mapAccumR f s' c
+--         where (s'', c') = B.mapAccumR f s' c
 --               (s', cs') = go s cs
 --
 -- -- ---------------------------------------------------------------------
@@ -898,7 +897,7 @@ iterate f = unfoldr (\x -> case f x of !x' -> Right (x', x'))
 zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 -}
 repeat :: Word8 -> ByteString m r
-repeat w = cs where cs = Chunk (S.replicate BI.smallChunkSize w) cs
+repeat w = cs where cs = Chunk (B.replicate BI.smallChunkSize w) cs
 {-# INLINABLE repeat #-}
 
 -- -- | /O(n)/ @'replicate' n x@ is a ByteString of length @n@ with @x@
@@ -907,11 +906,11 @@ repeat w = cs where cs = Chunk (S.replicate BI.smallChunkSize w) cs
 -- replicate :: Int64 -> Word8 -> ByteString
 -- replicate n w
 --     | n <= 0             = Empty
---     | n < fromIntegral smallChunkSize = Chunk (S.replicate (fromIntegral n) w) Empty
+--     | n < fromIntegral smallChunkSize = Chunk (B.replicate (fromIntegral n) w) Empty
 --     | r == 0             = cs -- preserve invariant
---     | otherwise          = Chunk (S.unsafeTake (fromIntegral r) c) cs
+--     | otherwise          = Chunk (B.unsafeTake (fromIntegral r) c) cs
 --  where
---     c      = S.replicate smallChunkSize w
+--     c      = B.replicate smallChunkSize w
 --     cs     = nChunks q
 --     (q, r) = quotRem n (fromIntegral smallChunkSize)
 --     nChunks 0 = Empty
@@ -941,9 +940,9 @@ cycle = forever
 unfoldM :: Monad m => (a -> Maybe (Word8, a)) -> a -> ByteString m ()
 unfoldM f s0 = unfoldChunk 32 s0
   where unfoldChunk n s =
-          case S.unfoldrN n f s of
+          case B.unfoldrN n f s of
             (c, Nothing)
-              | S.null c  -> Empty ()
+              | B.null c  -> Empty ()
               | otherwise -> Chunk c (Empty ())
             (c, Just s')  -> Chunk c (unfoldChunk (n*2) s')
 {-# INLINABLE unfoldM #-}
@@ -956,7 +955,7 @@ unfoldr f s0 = unfoldChunk 32 s0
   where unfoldChunk n s =
           case unfoldrNE n f s of
             (c, Left r)
-              | S.null c  -> Empty r
+              | B.null c  -> Empty r
               | otherwise -> Chunk c (Empty r)
             (c, Right s') -> Chunk c (unfoldChunk (n*2) s')
 {-# INLINABLE unfoldr #-}
@@ -987,9 +986,9 @@ take i cs0         = take' i cs0
   where take' 0 _            = Empty ()
         take' _ (Empty _)    = Empty ()
         take' n (Chunk c cs) =
-          if n < fromIntegral (S.length c)
-            then Chunk (S.take (fromIntegral n) c) (Empty ())
-            else Chunk c (take' (n - fromIntegral (S.length c)) cs)
+          if n < fromIntegral (B.length c)
+            then Chunk (B.take (fromIntegral n) c) (Empty ())
+            else Chunk c (take' (n - fromIntegral (B.length c)) cs)
         take' n (Go m) = Go (liftM (take' n) m)
 {-# INLINABLE take #-}
 
@@ -1008,9 +1007,9 @@ drop i cs0 = drop' i cs0
   where drop' 0 cs           = cs
         drop' _ (Empty r)    = Empty r
         drop' n (Chunk c cs) =
-          if n < fromIntegral (S.length c)
-            then Chunk (S.drop (fromIntegral n) c) cs
-            else drop' (n - fromIntegral (S.length c)) cs
+          if n < fromIntegral (B.length c)
+            then Chunk (B.drop (fromIntegral n) c) cs
+            else drop' (n - fromIntegral (B.length c)) cs
         drop' n (Go m) = Go (liftM (drop' n) m)
 {-# INLINABLE drop #-}
 
@@ -1029,10 +1028,10 @@ splitAt i cs0 = splitAt' i cs0
   where splitAt' 0 cs           = Empty cs
         splitAt' _ (Empty r  )   = Empty (Empty r)
         splitAt' n (Chunk c cs) =
-          if n < fromIntegral (S.length c)
-            then Chunk (S.take (fromIntegral n) c) $
-                     Empty (Chunk (S.drop (fromIntegral n) c) cs)
-            else Chunk c (splitAt' (n - fromIntegral (S.length c)) cs)
+          if n < fromIntegral (B.length c)
+            then Chunk (B.take (fromIntegral n) c) $
+                     Empty (Chunk (B.drop (fromIntegral n) c) cs)
+            else Chunk c (splitAt' (n - fromIntegral (B.length c)) cs)
         splitAt' n (Go m) = Go  (liftM (splitAt' n) m)
 {-# INLINABLE splitAt #-}
 
@@ -1047,7 +1046,7 @@ takeWhile f cs0 = takeWhile' cs0
     takeWhile' (Chunk c cs) =
       case findIndexOrEnd (not . f) c of
         0                  -> Empty ()
-        n | n < S.length c -> Chunk (S.take n c) (Empty ())
+        n | n < B.length c -> Chunk (B.take n c) (Empty ())
           | otherwise      -> Chunk c (takeWhile' cs)
 {-# INLINABLE takeWhile #-}
 
@@ -1059,7 +1058,7 @@ dropWhile p = drop' where
     Go m       -> Go (liftM drop' m)
     Chunk c cs -> case findIndexOrEnd (not . p) c of
         0                  -> Chunk c cs
-        n | n < S.length c -> Chunk (S.drop n c) cs
+        n | n < B.length c -> Chunk (B.drop n c) cs
           | otherwise      -> drop' cs
 {-# INLINABLE dropWhile #-}
 
@@ -1070,8 +1069,8 @@ break f cs0 = break' cs0
         break' (Chunk c cs) =
           case findIndexOrEnd f c of
             0                  -> Empty (Chunk c cs)
-            n | n < S.length c -> Chunk (S.take n c) $
-                                      Empty (Chunk (S.drop n c) cs)
+            n | n < B.length c -> Chunk (B.take n c) $
+                                      Empty (Chunk (B.drop n c) cs)
               | otherwise      -> Chunk c (break' cs)
         break' (Go m) = Go (liftM break' m)
 {-# INLINABLE break #-}
@@ -1133,14 +1132,14 @@ span p = break (not . p)
 splitWith :: Monad m => (Word8 -> Bool) -> ByteString m r -> Stream (ByteString m) m r
 splitWith _ (Empty r)      = Return r
 splitWith p (Go m)         = Effect $ liftM (splitWith p) m
-splitWith p (Chunk c0 cs0) = comb [] (S.splitWith p c0) cs0
+splitWith p (Chunk c0 cs0) = comb [] (B.splitWith p c0) cs0
   where
 -- comb :: [P.ByteString] -> [P.ByteString] -> ByteString -> [ByteString]
 --  comb acc (s:[]) (Empty r)    = Step (revChunks (s:acc) (Return r))
   comb acc [s]    (Empty r)    = Step $ L.foldl' (flip Chunk)
                                                  (Empty (Return r))
                                                  (s:acc)
-  comb acc [s]    (Chunk c cs) = comb (s:acc) (S.splitWith p c) cs
+  comb acc [s]    (Chunk c cs) = comb (s:acc) (B.splitWith p c) cs
   comb acc b      (Go m)       = Effect (liftM (comb acc b) m)
   comb acc (s:ss) cs           = Step $ L.foldl' (flip Chunk)
                                                  (Empty (comb [] ss cs))
@@ -1148,7 +1147,7 @@ splitWith p (Chunk c0 cs0) = comb [] (S.splitWith p c0) cs0
   comb acc []  (Empty r)    = Step $ L.foldl' (flip Chunk)
                                                  (Empty (Return r))
                                                  acc
-  comb acc []  (Chunk c cs) = comb acc (S.splitWith p c) cs
+  comb acc []  (Chunk c cs) = comb acc (B.splitWith p c) cs
  --  comb acc (s:ss) cs           = Step (revChunks (s:acc) (comb [] ss cs))
 
 {-# INLINABLE splitWith #-}
@@ -1175,11 +1174,11 @@ split w = loop
   loop !x = case x of
     Empty r      -> Return r
     Go m         -> Effect $ liftM loop m
-    Chunk c0 cs0 -> comb [] (S.split w c0) cs0
+    Chunk c0 cs0 -> comb [] (B.split w c0) cs0
   comb !acc [] (Empty r)       = Step $ revChunks acc (Return r)
-  comb acc [] (Chunk c cs)     = comb acc (S.split w c) cs
+  comb acc [] (Chunk c cs)     = comb acc (B.split w c) cs
   comb !acc (s:[]) (Empty r)   = Step $ revChunks (s:acc) (Return r)
-  comb acc (s:[]) (Chunk c cs) = comb (s:acc) (S.split w c) cs
+  comb acc (s:[]) (Chunk c cs) = comb (s:acc) (B.split w c) cs
   comb acc b (Go m)            = Effect (liftM (comb acc b) m)
   comb acc (s:ss) cs           = Step $ revChunks (s:acc) (comb [] ss cs)
 {-# INLINABLE split #-}
@@ -1201,15 +1200,15 @@ group = go
     go (Empty r)        = Return r
     go (Go m)           = Effect $ liftM go m
     go (Chunk c cs)
-      | S.length c == 1 = Step $ to [c] (S.unsafeHead c) cs
-      | otherwise       = Step $ to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+      | B.length c == 1 = Step $ to [c] (B.unsafeHead c) cs
+      | otherwise       = Step $ to [B.unsafeTake 1 c] (B.unsafeHead c) (Chunk (B.unsafeTail c) cs)
 
     to acc !_ (Empty r) = revNonEmptyChunks acc (Empty (Return r))
     to acc !w (Go m) = Go $ to acc w <$> m
     to acc !w (Chunk c cs) = case findIndexOrEnd (/= w) c of
       0 -> revNonEmptyChunks acc (Empty (go (Chunk c cs)))
-      n | n == S.length c -> to (S.unsafeTake n c : acc) w cs
-        | otherwise       -> revNonEmptyChunks (S.unsafeTake n c : acc) (Empty (go (Chunk (S.unsafeDrop n c) cs)))
+      n | n == B.length c -> to (B.unsafeTake n c : acc) w cs
+        | otherwise       -> revNonEmptyChunks (B.unsafeTake n c : acc) (Empty (go (Chunk (B.unsafeDrop n c) cs)))
 {-# INLINABLE group #-}
 
 -- | The 'groupBy' function is a generalized version of 'group'.
@@ -1219,15 +1218,15 @@ groupBy rel = go
     go (Empty r)        = Return r
     go (Go m)           = Effect $ liftM go m
     go (Chunk c cs)
-      | S.length c == 1 = Step $ to [c] (S.unsafeHead c) cs
-      | otherwise       = Step $ to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+      | B.length c == 1 = Step $ to [c] (B.unsafeHead c) cs
+      | otherwise       = Step $ to [B.unsafeTake 1 c] (B.unsafeHead c) (Chunk (B.unsafeTail c) cs)
 
     to acc !_ (Empty r) = revNonEmptyChunks acc (Empty (Return r))
     to acc !w (Go m) = Go $ to acc w <$> m
     to acc !w (Chunk c cs) = case findIndexOrEnd (not . rel w) c of
       0 -> revNonEmptyChunks acc (Empty (go (Chunk c cs)))
-      n | n == S.length c  -> to (S.unsafeTake n c : acc) w cs
-        | otherwise        -> revNonEmptyChunks (S.unsafeTake n c : acc) (Empty (go (Chunk (S.unsafeDrop n c) cs)))
+      n | n == B.length c  -> to (B.unsafeTake n c : acc) w cs
+        | otherwise        -> revNonEmptyChunks (B.unsafeTake n c : acc) (Empty (go (Chunk (B.unsafeDrop n c) cs)))
 {-# INLINABLE groupBy #-}
 
 -- -- | The 'groupBy' function is the non-overloaded version of 'group'.
@@ -1237,17 +1236,17 @@ groupBy rel = go
 --   where
 --     go Empty        = []
 --     go (Chunk c cs)
---       | S.length c == 1  = to [c] (S.unsafeHead c) cs
---       | otherwise        = to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+--       | B.length c == 1  = to [c] (B.unsafeHead c) cs
+--       | otherwise        = to [B.unsafeTake 1 c] (B.unsafeHead c) (Chunk (B.unsafeTail c) cs)
 --
 --     to acc !_ Empty        = revNonEmptyChunks acc : []
 --     to acc !w (Chunk c cs) =
 --       case findIndexOrEnd (not . k w) c of
 --         0                    -> revNonEmptyChunks acc
 --                               : go (Chunk c cs)
---         n | n == S.length c  -> to (S.unsafeTake n c : acc) w cs
---           | otherwise        -> revNonEmptyChunks (S.unsafeTake n c : acc)
---                               : go (Chunk (S.unsafeDrop n c) cs)
+--         n | n == B.length c  -> to (B.unsafeTake n c : acc) w cs
+--           | otherwise        -> revNonEmptyChunks (B.unsafeTake n c : acc)
+--                               : go (Chunk (B.unsafeDrop n c) cs)
 --
 -- | /O(n)/ The 'intercalate' function takes a 'ByteString' and a list of
 -- 'ByteString's and concatenates the list after interspersing the first
@@ -1275,12 +1274,12 @@ intercalate s (Step bs0) = do  -- this isn't quite right
 -- > count = length . elemIndices
 --
 count_ :: Monad m => Word8 -> ByteString m r -> m Int
-count_ w  = liftM (\(n :> _) -> n) . foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0
+count_ w  = liftM (\(n :> _) -> n) . foldlChunks (\n c -> n + fromIntegral (B.count w c)) 0
 {-# INLINE count_ #-}
 
 -- But more efficiently than using length on the intermediate list.
 count :: Monad m => Word8 -> ByteString m r -> m (Of Int r)
-count w cs = foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0 cs
+count w cs = foldlChunks (\n c -> n + fromIntegral (B.count w c)) 0 cs
 {-# INLINE count #-}
 
 -- -- | The 'findIndex' function takes a predicate and a 'ByteString' and
@@ -1290,8 +1289,8 @@ count w cs = foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0 cs
 -- findIndex k cs0 = findIndex' 0 cs0
 --   where findIndex' _ Empty        = Nothing
 --         findIndex' n (Chunk c cs) =
---           case S.findIndex k c of
---             Nothing -> findIndex' (n + fromIntegral (S.length c)) cs
+--           case B.findIndex k c of
+--             Nothing -> findIndex' (n + fromIntegral (B.length c)) cs
 --             Just i  -> Just (n + fromIntegral i)
 -- {-# INLINE findIndex #-}
 --
@@ -1304,7 +1303,7 @@ count w cs = foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0 cs
 -- find :: (Word8 -> Bool) -> ByteString -> Maybe Word8
 -- find f cs0 = find' cs0
 --   where find' Empty        = Nothing
---         find' (Chunk c cs) = case S.find f c of
+--         find' (Chunk c cs) = case B.find f c of
 --             Nothing -> find' cs
 --             Just w  -> Just w
 -- {-# INLINE find #-}
@@ -1314,8 +1313,8 @@ count w cs = foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0 cs
 -- findIndices :: (Word8 -> Bool) -> ByteString -> [Int64]
 -- findIndices k cs0 = findIndices' 0 cs0
 --   where findIndices' _ Empty        = []
---         findIndices' n (Chunk c cs) = L.map ((+n).fromIntegral) (S.findIndices k c)
---                              ++ findIndices' (n + fromIntegral (S.length c)) cs
+--         findIndices' n (Chunk c cs) = L.map ((+n).fromIntegral) (B.findIndices k c)
+--                              ++ findIndices' (n + fromIntegral (B.length c)) cs
 --
 -- ---------------------------------------------------------------------
 -- Searching ByteStrings
@@ -1327,7 +1326,7 @@ filter :: Monad m => (Word8 -> Bool) -> ByteString m r -> ByteString m r
 filter p s = go s
     where
         go (Empty r )   = Empty r
-        go (Chunk x xs) = consChunk (S.filter p x) (go xs)
+        go (Chunk x xs) = consChunk (B.filter p x) (go xs)
         go (Go m)       = Go (liftM go m)
                             -- should inspect for null
 {-# INLINABLE filter #-}
@@ -1386,15 +1385,15 @@ filter p s = go s
 -- zipWith _ _      Empty = []
 -- zipWith f (Chunk a as) (Chunk b bs) = go a as b bs
 --   where
---     go x xs y ys = f (S.unsafeHead x) (S.unsafeHead y)
---                  : to (S.unsafeTail x) xs (S.unsafeTail y) ys
+--     go x xs y ys = f (B.unsafeHead x) (B.unsafeHead y)
+--                  : to (B.unsafeTail x) xs (B.unsafeTail y) ys
 --
---     to x Empty         _ _             | S.null x       = []
---     to _ _             y Empty         | S.null y       = []
---     to x xs            y ys            | not (S.null x)
---                                       && not (S.null y) = go x  xs y  ys
---     to x xs            _ (Chunk y' ys) | not (S.null x) = go x  xs y' ys
---     to _ (Chunk x' xs) y ys            | not (S.null y) = go x' xs y  ys
+--     to x Empty         _ _             | B.null x       = []
+--     to _ _             y Empty         | B.null y       = []
+--     to x xs            y ys            | not (B.null x)
+--                                       && not (B.null y) = go x  xs y  ys
+--     to x xs            _ (Chunk y' ys) | not (B.null x) = go x  xs y' ys
+--     to _ (Chunk x' xs) y ys            | not (B.null y) = go x' xs y  ys
 --     to _ (Chunk x' xs) _ (Chunk y' ys)                  = go x' xs y' ys
 --
 -- -- | /O(n)/ 'unzip' transforms a list of pairs of bytes into a pair of
@@ -1425,9 +1424,9 @@ hGetContentsN k h = loop -- TODO close on exceptions
   where
 --    lazyRead = unsafeInterleaveIO loop
     loop = do
-        c <- liftIO (S.hGetSome h k)
+        c <- liftIO (B.hGetSome h k)
         -- only blocks if there is no data available
-        if S.null c
+        if B.null c
           then Empty ()
           else Chunk c loop
 {-# INLINABLE hGetContentsN #-} -- very effective inline pragma
@@ -1439,8 +1438,8 @@ hGetN :: MonadIO m => Int -> Handle -> Int -> ByteString m ()
 hGetN k h n | n > 0 = readChunks n
   where
     readChunks !i = Go $ do
-        c <- liftIO $ S.hGet h (min k i)
-        case S.length c of
+        c <- liftIO $ B.hGet h (min k i)
+        case B.length c of
             0 -> return $ Empty ()
             m -> return $ Chunk c (readChunks (i - m))
 
@@ -1456,8 +1455,8 @@ hGetNonBlockingN :: MonadIO m => Int -> Handle -> Int ->  ByteString m ()
 hGetNonBlockingN k h n | n > 0 = readChunks n
   where
     readChunks !i = Go $ do
-        c <- liftIO $ S.hGetNonBlocking h (min k i)
-        case S.length c of
+        c <- liftIO $ B.hGetNonBlocking h (min k i)
+        case B.length c of
             0 -> return (Empty ())
             m -> return (Chunk c (readChunks (i - m)))
 hGetNonBlockingN _ _ 0 = Empty ()
@@ -1584,7 +1583,7 @@ getContents = hGetContents IO.stdin
 -- | Outputs a 'ByteString' to the specified 'Handle'.
 --
 hPut ::  MonadIO m => Handle -> ByteString m r -> m r
-hPut h cs = dematerialize cs return (\x y -> liftIO (S.hPut h x) >> y) (>>= id)
+hPut h cs = dematerialize cs return (\x y -> liftIO (B.hPut h x) >> y) (>>= id)
 {-# INLINE hPut #-}
 
 -- | Pipes nomenclature for 'hPut'
@@ -1609,9 +1608,9 @@ stdout = hPut IO.stdout
 -- hPutNonBlocking _ (Empty r)         = Empty r
 -- hPutNonBlocking h (Go m) = Go $ liftM (hPutNonBlocking h) m
 -- hPutNonBlocking h bs@(Chunk c cs) = do
---   c' <- lift $ S.hPutNonBlocking h c
---   case S.length c' of
---     l' | l' == S.length c -> hPutNonBlocking h cs
+--   c' <- lift $ B.hPutNonBlocking h c
+--   case B.length c' of
+--     l' | l' == B.length c -> hPutNonBlocking h cs
 --     0                     -> bs
 --     _                     -> Chunk c' cs
 -- {-# INLINABLE hPutNonBlocking #-}
@@ -1675,8 +1674,8 @@ revChunks cs r = L.foldl' (flip Chunk) (Empty r) cs
 -- | 'findIndexOrEnd' is a variant of findIndex, that returns the length
 -- of the string if no element is found, rather than Nothing.
 findIndexOrEnd :: (Word8 -> Bool) -> P.ByteString -> Int
-findIndexOrEnd k (S.PS x s l) =
-    unsafeDupablePerformIO $
+findIndexOrEnd k (B.PS x s l) =
+    B.accursedUnutterablePerformIO $
       withForeignPtr x $ \f -> go (f `plusPtr` s) 0
   where
     go !ptr !n | n >= l    = return l
@@ -1734,8 +1733,8 @@ toStreamingByteStringWith strategy builder0 = do
                     loop cios1
               Finished buf r -> trimmedChunkFromBuffer buf (Empty r)
            trimmedChunkFromBuffer buffer k
-              | S.null bs                            = k
-              |  2 * S.length bs < bufferSize buffer = Chunk (S.copy bs) k
+              | B.null bs                            = k
+              |  2 * B.length bs < bufferSize buffer = Chunk (B.copy bs) k
               | otherwise                            = Chunk bs          k
               where
                 bs = byteStringFromBuffer buffer

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -196,7 +196,6 @@ import           Foreign.ForeignPtr (withForeignPtr)
 import           Foreign.Ptr
 import           Foreign.Storable
 import qualified System.IO as IO
-import           System.IO.Unsafe (unsafeDupablePerformIO)
 
 unpack ::  Monad m => ByteString m r ->  Stream (Of Char) m r
 unpack bs = case bs of
@@ -213,7 +212,7 @@ unpack bs = case bs of
 
   unpackAppendCharsStrict :: B.ByteString -> Stream (Of Char) m r -> Stream (Of Char) m r
   unpackAppendCharsStrict (B.PS fp off len) xs =
-    unsafeDupablePerformIO $ withForeignPtr fp $ \base -> do
+    B.accursedUnutterablePerformIO $ withForeignPtr fp $ \base -> do
          loop (base `plusPtr` (off-1)) (base `plusPtr` (off-1+len)) xs
      where
        loop !sentinal !p acc
@@ -658,7 +657,7 @@ nthNewLine :: B.ByteString   -- input chunk
            -> Int            -- remaining number of newlines wanted
            -> Either Int Int -- Left count, else Right length
 nthNewLine (B.PS fp off len) targetLines =
-    unsafeDupablePerformIO $ withForeignPtr fp $ \base ->
+    B.accursedUnutterablePerformIO $ withForeignPtr fp $ \base ->
     loop (base `plusPtr` off) targetLines 0 len
   where
     loop :: Ptr Word8 -> Int -> Int -> Int -> IO (Either Int Int)

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -196,7 +196,7 @@ import           Foreign.ForeignPtr (withForeignPtr)
 import           Foreign.Ptr
 import           Foreign.Storable
 import qualified System.IO as IO
-import           System.IO.Unsafe
+import           System.IO.Unsafe (unsafeDupablePerformIO)
 
 unpack ::  Monad m => ByteString m r ->  Stream (Of Char) m r
 unpack bs = case bs of
@@ -213,7 +213,7 @@ unpack bs = case bs of
 
   unpackAppendCharsStrict :: B.ByteString -> Stream (Of Char) m r -> Stream (Of Char) m r
   unpackAppendCharsStrict (B.PS fp off len) xs =
-    inlinePerformIO $ withForeignPtr fp $ \base -> do
+    unsafeDupablePerformIO $ withForeignPtr fp $ \base -> do
          loop (base `plusPtr` (off-1)) (base `plusPtr` (off-1+len)) xs
      where
        loop !sentinal !p acc

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -37,7 +37,6 @@ module Data.ByteString.Streaming.Internal (
    , mwrap
    , unfoldrNE
    , reread
-   , inlinePerformIO
    , unsafeLast
    , unsafeInit
    , copy
@@ -339,7 +338,7 @@ unpackBytes bss = dematerialize bss
 
   unpackAppendBytesStrict :: S.ByteString -> Stream (Of Word8) m r -> Stream (Of Word8) m r
   unpackAppendBytesStrict (S.PS fp off len) xs =
-    inlinePerformIO $ withForeignPtr fp $ \base ->
+    unsafeDupablePerformIO $ withForeignPtr fp $ \base ->
       loop (base `plusPtr` (off-1)) (base `plusPtr` (off-1+len)) xs
     where
       loop !sentinal !p acc
@@ -361,9 +360,6 @@ unsafeLast (S.PS x s l) =
 unsafeInit :: S.ByteString -> S.ByteString
 unsafeInit (S.PS ps s l) = S.PS ps s (l-1)
 {-# INLINE unsafeInit #-}
-
-inlinePerformIO :: IO a -> a
-inlinePerformIO (IO m) = case m realWorld# of (# _, r #) -> r
 
 -- | Consume the chunks of an effectful ByteString with a natural right fold.
 foldrChunks :: Monad m => (S.ByteString -> a -> a) -> a -> ByteString m r -> m a

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -58,6 +58,10 @@ import           Prelude hiding
     unlines, unzip, writeFile, zip, zipWith)
 import qualified Prelude
 
+#if !MIN_VERSION_base(4,9,0)
+import           Data.Semigroup
+#endif
+
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Internal as S
 

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -58,7 +58,7 @@ import           Prelude hiding
     unlines, unzip, writeFile, zip, zipWith)
 import qualified Prelude
 
-#if !MIN_VERSION_base(4,9,0)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
 #endif
 

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -61,8 +61,8 @@ import qualified Prelude
 import           Data.Semigroup
 #endif
 
-import qualified Data.ByteString as S
-import qualified Data.ByteString.Internal as S
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Internal as B
 
 import           Streaming (Of(..))
 import           Streaming.Internal hiding (concats)
@@ -93,7 +93,7 @@ import           Control.Monad.Trans.Resource
 
 data ByteString m r =
   Empty r
-  | Chunk {-# UNPACK #-} !S.ByteString (ByteString m r )
+  | Chunk {-# UNPACK #-} !B.ByteString (ByteString m r )
   | Go (m (ByteString m r ))
 
 instance Monad m => Functor (ByteString m) where
@@ -147,7 +147,7 @@ instance MFunctor ByteString where
   {-# INLINABLE hoist #-}
 
 instance (r ~ ()) => IsString (ByteString m r) where
-  fromString = chunk . S.pack . Prelude.map S.c2w
+  fromString = chunk . B.pack . Prelude.map B.c2w
   {-# INLINE fromString #-}
 
 instance (m ~ Identity, Show r) => Show (ByteString m r) where
@@ -210,14 +210,14 @@ data SPEC = SPEC | SPEC2
 -- -- ------------------------------------------------------------------------
 --
 -- | Smart constructor for 'Chunk'.
-consChunk :: S.ByteString -> ByteString m r -> ByteString m r
-consChunk c@(S.PS _ _ len) cs
+consChunk :: B.ByteString -> ByteString m r -> ByteString m r
+consChunk c@(B.PS _ _ len) cs
   | len == 0  = cs
   | otherwise = Chunk c cs
 {-# INLINE consChunk #-}
 
 -- | Yield-style smart constructor for 'Chunk'.
-chunk :: S.ByteString -> ByteString m ()
+chunk :: B.ByteString -> ByteString m ()
 chunk bs = consChunk bs (Empty ())
 {-# INLINE chunk #-}
 
@@ -234,7 +234,7 @@ mwrap = Go
 {-# INLINE mwrap #-}
 
 -- | Construct a succession of chunks from its Church encoding (compare @GHC.Exts.build@)
-materialize :: (forall x . (r -> x) -> (S.ByteString -> x -> x) -> (m x -> x) -> x)
+materialize :: (forall x . (r -> x) -> (B.ByteString -> x -> x) -> (m x -> x) -> x)
             -> ByteString m r
 materialize phi = phi Empty Chunk Go
 {-# INLINE[0] materialize #-}
@@ -243,7 +243,7 @@ materialize phi = phi Empty Chunk Go
 -- not a safe operation; it is equivalent to exposing the constructors
 dematerialize :: Monad m
               => ByteString m r
-              -> (forall x . (r -> x) -> (S.ByteString -> x -> x) -> (m x -> x) -> x)
+              -> (forall x . (r -> x) -> (B.ByteString -> x -> x) -> (m x -> x) -> x)
 dematerialize x0 nil cons mwrap' = loop SPEC x0
   where
   loop !_ x = case x of
@@ -253,7 +253,7 @@ dematerialize x0 nil cons mwrap' = loop SPEC x0
 {-# INLINE [1] dematerialize #-}
 
 {-# RULES
-  "dematerialize/materialize" forall (phi :: forall b . (r -> b) -> (S.ByteString -> b -> b) -> (m b -> b)  -> b). dematerialize (materialize phi) = phi ;
+  "dematerialize/materialize" forall (phi :: forall b . (r -> b) -> (B.ByteString -> b -> b) -> (m b -> b)  -> b). dematerialize (materialize phi) = phi ;
   #-}
 ------------------------------------------------------------------------
 
@@ -289,21 +289,21 @@ chunkOverhead = 2 * sizeOf (undefined :: Int)
 -- packBytes' cs0 =
 --     packChunks 32 cs0
 --   where
---     packChunks n cs = case S.packUptoLenBytes n cs of
+--     packChunks n cs = case B.packUptoLenBytes n cs of
 --       (bs, [])  -> Chunk bs (Empty ())
 --       (bs, cs') -> Chunk bs (packChunks (min (n * 2) BI.smallChunkSize) cs')
 --     -- packUptoLenBytes :: Int -> [Word8] -> (ByteString, [Word8])
 --     packUptoLenBytes len xs0 =
---         unsafeDupablePerformIO (createUptoN' len $ \p -> go p len xs0)
+--         accursedUnutterablePerformIO (createUptoN' len $ \p -> go p len xs0)
 --       where
 --         go !_ !n []     = return (len-n, [])
 --         go !_ !0 xs     = return (len,   xs)
 --         go !p !n (x:xs) = poke p x >> go (p `plusPtr` 1) (n-1) xs
---         createUptoN' :: Int -> (Ptr Word8 -> IO (Int, a)) -> IO (S.ByteString, a)
+--         createUptoN' :: Int -> (Ptr Word8 -> IO (Int, a)) -> IO (B.ByteString, a)
 --         createUptoN' l f = do
---             fp <- S.mallocByteString l
+--             fp <- B.mallocByteString l
 --             (l', res) <- withForeignPtr fp $ \p -> f p
---             assert (l' <= l) $ return (S.PS fp 0 l', res)
+--             assert (l' <= l) $ return (B.PS fp 0 l', res)
 -- {-# INLINABLE packBytes' #-}
 
 packBytes :: Monad m => Stream (Of Word8) m r -> ByteString m r
@@ -314,11 +314,11 @@ packBytes cs0 = do
       Return r -> Empty r
       Step as  -> packBytes (Step as)  -- these two pattern matches
       Effect m -> Go $ liftM packBytes m -- should be evaded.
-    _  -> Chunk (S.packBytes bytes) (packBytes rest)
+    _  -> Chunk (B.packBytes bytes) (packBytes rest)
 {-# INLINABLE packBytes #-}
 
 packChars :: Monad m => Stream (Of Char) m r -> ByteString m r
-packChars = packBytes . SP.map S.c2w
+packChars = packBytes . SP.map B.c2w
 {-# INLINABLE packChars #-}
 
 
@@ -329,16 +329,16 @@ unpackBytes bss = dematerialize bss
     unpackAppendBytesLazy
     Effect
   where
-  unpackAppendBytesLazy :: S.ByteString -> Stream (Of Word8) m r -> Stream (Of Word8) m r
-  unpackAppendBytesLazy (S.PS fp off len) xs
-    | len <= 100 = unpackAppendBytesStrict (S.PS fp off len) xs
-    | otherwise  = unpackAppendBytesStrict (S.PS fp off 100) remainder
+  unpackAppendBytesLazy :: B.ByteString -> Stream (Of Word8) m r -> Stream (Of Word8) m r
+  unpackAppendBytesLazy (B.PS fp off len) xs
+    | len <= 100 = unpackAppendBytesStrict (B.PS fp off len) xs
+    | otherwise  = unpackAppendBytesStrict (B.PS fp off 100) remainder
     where
-      remainder  = unpackAppendBytesLazy (S.PS fp (off+100) (len-100)) xs
+      remainder  = unpackAppendBytesLazy (B.PS fp (off+100) (len-100)) xs
 
-  unpackAppendBytesStrict :: S.ByteString -> Stream (Of Word8) m r -> Stream (Of Word8) m r
-  unpackAppendBytesStrict (S.PS fp off len) xs =
-    unsafeDupablePerformIO $ withForeignPtr fp $ \base ->
+  unpackAppendBytesStrict :: B.ByteString -> Stream (Of Word8) m r -> Stream (Of Word8) m r
+  unpackAppendBytesStrict (B.PS fp off len) xs =
+    B.accursedUnutterablePerformIO $ withForeignPtr fp $ \base ->
       loop (base `plusPtr` (off-1)) (base `plusPtr` (off-1+len)) xs
     where
       loop !sentinal !p acc
@@ -349,27 +349,27 @@ unpackBytes bss = dematerialize bss
 {-# INLINABLE unpackBytes #-}
 
 -- copied from Data.ByteString.Unsafe for compatibility with older bytestring
-unsafeLast :: S.ByteString -> Word8
-unsafeLast (S.PS x s l) =
+unsafeLast :: B.ByteString -> Word8
+unsafeLast (B.PS x s l) =
     accursedUnutterablePerformIO $ withForeignPtr x $ \p -> peekByteOff p (s+l-1)
  where
       accursedUnutterablePerformIO (IO m) = case m realWorld# of (# _, r #) -> r
 {-# INLINE unsafeLast #-}
 
 -- copied from Data.ByteString.Unsafe for compatibility with older bytestring
-unsafeInit :: S.ByteString -> S.ByteString
-unsafeInit (S.PS ps s l) = S.PS ps s (l-1)
+unsafeInit :: B.ByteString -> B.ByteString
+unsafeInit (B.PS ps s l) = B.PS ps s (l-1)
 {-# INLINE unsafeInit #-}
 
 -- | Consume the chunks of an effectful ByteString with a natural right fold.
-foldrChunks :: Monad m => (S.ByteString -> a -> a) -> a -> ByteString m r -> m a
+foldrChunks :: Monad m => (B.ByteString -> a -> a) -> a -> ByteString m r -> m a
 foldrChunks step nil bs = dematerialize bs
   (\_ -> return nil)
   (liftM . step)
   join
 {-# INLINE foldrChunks #-}
 
-foldlChunks :: Monad m => (a -> S.ByteString -> a) -> a -> ByteString m r -> m (Of a r)
+foldlChunks :: Monad m => (a -> B.ByteString -> a) -> a -> ByteString m r -> m (Of a r)
 foldlChunks f z = go z
   where go a _            | a `seq` False = undefined
         go a (Empty r)    = return (a :> r)
@@ -377,15 +377,15 @@ foldlChunks f z = go z
         go a (Go m)       = m >>= go a
 {-# INLINABLE foldlChunks #-}
 
-chunkMap :: Monad m => (S.ByteString -> S.ByteString) -> ByteString m r -> ByteString m r
+chunkMap :: Monad m => (B.ByteString -> B.ByteString) -> ByteString m r -> ByteString m r
 chunkMap f bs = dematerialize bs return (\bs' bss -> Chunk (f bs') bss) Go
 {-# INLINE chunkMap #-}
 
-chunkMapM :: Monad m => (S.ByteString -> m S.ByteString) -> ByteString m r -> ByteString m r
+chunkMapM :: Monad m => (B.ByteString -> m B.ByteString) -> ByteString m r -> ByteString m r
 chunkMapM f bs = dematerialize bs return (\bs' bss -> Go (liftM (flip Chunk bss) (f bs'))) Go
 {-# INLINE chunkMapM #-}
 
-chunkMapM_ :: Monad m => (S.ByteString -> m x) -> ByteString m r -> m r
+chunkMapM_ :: Monad m => (B.ByteString -> m x) -> ByteString m r -> m r
 chunkMapM_ f bs = dematerialize bs return (\bs' mr -> f bs' >> mr) join
 {-# INLINE chunkMapM_ #-}
 
@@ -395,7 +395,7 @@ chunkMapM_ f bs = dematerialize bs return (\bs' mr -> f bs' >> mr) join
      permits many folds and sinks to be run simulaneously on one bytestream.
 
   -}
-chunkFold :: Monad m => (x -> S.ByteString -> x) -> x -> (x -> a) -> ByteString m r -> m (Of a r)
+chunkFold :: Monad m => (x -> B.ByteString -> x) -> x -> (x -> a) -> ByteString m r -> m (Of a r)
 chunkFold step begin done = go begin
   where go a _            | a `seq` False = undefined
         go a (Empty r)    = return (done a :> r)
@@ -408,7 +408,7 @@ chunkFold step begin done = go begin
      permits many folds and sinks to be run simulaneously on one bytestream.
 
   -}
-chunkFoldM :: Monad m => (x -> S.ByteString -> m x) -> m x -> (x -> m a) -> ByteString m r -> m (Of a r)
+chunkFoldM :: Monad m => (x -> B.ByteString -> m x) -> m x -> (x -> m a) -> ByteString m r -> m (Of a r)
 chunkFoldM step begin done bs = begin >>= go bs
   where
     go str !x = case str of
@@ -417,7 +417,7 @@ chunkFoldM step begin done bs = begin >>= go bs
       Go m       -> m >>= \str' -> go str' x
 {-# INLINABLE chunkFoldM  #-}
 
-foldlChunksM :: Monad m => (a -> S.ByteString -> m a) -> m a -> ByteString m r -> m (Of a r)
+foldlChunksM :: Monad m => (a -> B.ByteString -> m a) -> m a -> ByteString m r -> m (Of a r)
 foldlChunksM f z bs = z >>= \a -> go a bs
   where
     go !a str = case str of
@@ -429,17 +429,17 @@ foldlChunksM f z bs = z >>= \a -> go a bs
 
 
 -- | Consume the chunks of an effectful ByteString with a natural right monadic fold.
-foldrChunksM :: Monad m => (S.ByteString -> m a -> m a) -> m a -> ByteString m r -> m a
+foldrChunksM :: Monad m => (B.ByteString -> m a -> m a) -> m a -> ByteString m r -> m a
 foldrChunksM step nil bs = dematerialize bs
   (\_ -> nil)
   step
   join
 {-# INLINE foldrChunksM #-}
 
-unfoldrNE :: Int -> (a -> Either r (Word8, a)) -> a -> (S.ByteString, Either r a)
+unfoldrNE :: Int -> (a -> Either r (Word8, a)) -> a -> (B.ByteString, Either r a)
 unfoldrNE i f x0
-    | i < 0     = (S.empty, Right x0)
-    | otherwise = unsafePerformIO $ S.createAndTrim' i $ \p -> go p x0 0
+    | i < 0     = (B.empty, Right x0)
+    | otherwise = unsafePerformIO $ B.createAndTrim' i $ \p -> go p x0 0
   where
     go !p !x !n
       | n == i    = return (0, n, Right x)
@@ -450,7 +450,7 @@ unfoldrNE i f x0
 {-# INLINE unfoldrNE #-}
 
 
-unfoldMChunks :: Monad m => (s -> m (Maybe (S.ByteString, s))) -> s -> ByteString m ()
+unfoldMChunks :: Monad m => (s -> m (Maybe (B.ByteString, s))) -> s -> ByteString m ()
 unfoldMChunks step = loop where
   loop s = Go $ do
     m <- step s
@@ -459,7 +459,7 @@ unfoldMChunks step = loop where
       Just (bs,s') -> return $ Chunk bs (loop s')
 {-# INLINABLE unfoldMChunks #-}
 
-unfoldrChunks :: Monad m => (s -> m (Either r (S.ByteString, s))) -> s -> ByteString m r
+unfoldrChunks :: Monad m => (s -> m (Either r (B.ByteString, s))) -> s -> ByteString m r
 unfoldrChunks step = loop where
   loop !s = Go $ do
     m <- step s
@@ -473,15 +473,15 @@ unfoldrChunks step = loop where
     until it returns @Nothing@. @reread@ is of particular use rendering @io-streams@
     input streams as byte streams in the present sense
 
-> Q.reread Streams.read             :: InputStream S.ByteString -> Q.ByteString IO ()
-> Q.reread (liftIO . Streams.read)  :: MonadIO m => InputStream S.ByteString -> Q.ByteString m ()
+> Q.reread Streams.read             :: InputStream B.ByteString -> Q.ByteString IO ()
+> Q.reread (liftIO . Streams.read)  :: MonadIO m => InputStream B.ByteString -> Q.ByteString m ()
 
 The other direction here is
 
-> Streams.unfoldM Q.unconsChunk     :: Q.ByteString IO r -> IO (InputStream S.ByteString)
+> Streams.unfoldM Q.unconsChunk     :: Q.ByteString IO r -> IO (InputStream B.ByteString)
 
   -}
-reread :: Monad m => (s -> m (Maybe S.ByteString)) -> s -> ByteString m ()
+reread :: Monad m => (s -> m (Maybe B.ByteString)) -> s -> ByteString m ()
 reread step s = loop where
   loop = Go $ do
     m <- step s

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
 resolver: lts-16.14
+
+ghc-options:
+  $locals: -fmax-relevant-binds=0 -funclutter-valid-hole-fits

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-16.13
+resolver: lts-16.14

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,1 @@
 resolver: lts-16.14
-
-ghc-options:
-  $locals: -fmax-relevant-binds=0 -funclutter-valid-hole-fits

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -1,239 +1,258 @@
-name:                streaming-bytestring
-version:             0.1.6
-synopsis:            effectful byte steams, or: bytestring io done right.
+cabal-version:      >=1.10
+name:               streaming-bytestring
+version:            0.1.6
+synopsis:           effectful byte steams, or: bytestring io done right.
+description:
+  This is an implementation of effectful, memory-constrained
+  bytestrings (byte streams) and functions for streaming
+  bytestring manipulation, adequate for non-lazy-io.
+  Some examples of the use of byte streams to implement simple
+  shell progams can be found
+  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>.
+  See also the illustrations of use with e.g. @attoparsec@,
+  @aeson@, @http-client@, @zlib@ etc. in the
+  <https://hackage.haskell.org/package/streaming-utils streaming-utils>
+  library.  Usage is as close as possible to that of @ByteString@
+  and lazy @ByteString@.
+  .
+  A @ByteString IO ()@ is the most natural representation of
+  an effectful stream of bytes arising chunkwise from a handle.
+  Indeed, the implementation follows the
+  details of @Data.ByteString.Lazy@ and @Data.ByteString.Lazy.Char8@
+  in unrelenting detail, omitting only transparently non-streaming
+  operations like @reverse@. It is just a question of replacing
+  the lazy bytestring type:
+  .
+  > data ByteString     = Empty   | Chunk Strict.ByteString ByteString
+  .
+  with the /minimal/ effectful variant:
+  .
+  > data ByteString m r = Empty r | Chunk Strict.ByteString (ByteString m r) | Go (m (ByteString m r))
+  .
+  (Constructors are necessarily hidden in internal modules in both the @Lazy@ and the @Streaming@.)
+  .
+  That's it. As a lazy bytestring is implemented internally
+  by a sort of list of strict bytestring chunks, a streaming bytestring is
+  simply implemented as a /producer/ or /generator/ of strict bytestring chunks.
+  Most operations are defined by simply adding a line to what we find in
+  @Data.ByteString.Lazy@. The only possible simplification would
+  involve specializing to @IO@, throughout - but this would e.g. block
+  the use of @ResourceT@ to manage handles and the like, and a number
+  of other convenient operations like @copy@, which permits one to
+  apply two operations simultaneously over the length of the byte stream.
+  .
+  Something like this alteration of type is of course obvious and mechanical, once the idea of
+  an effectful bytestring type is contemplated and lazy io is rejected.
+  Indeed it seems that this is the proper expression of what was
+  intended by lazy bytestrings to begin with. The documentation, after all,
+  reads
+  .
+  * \"A key feature of lazy ByteStrings is the means to manipulate large or
+  unbounded streams of data without requiring the entire sequence to be
+  resident in memory. To take advantage of this you have to write your
+  functions in a lazy streaming style, e.g. classic pipeline composition.
+  The default I/O chunk size is 32k, which should be good in most circumstances.\"
+  .
+  ... which is very much the idea of this library: the default chunk size for
+  'hGetContents' and the like follows @Data.ByteString.Lazy@; operations
+  like @lines@ and @append@ and so on are tailored not to increase chunk size.
+  .
+  The present library is thus if you like nothing but /lazy bytestring done right/.
+  The authors of @Data.ByteString.Lazy@ must have supposed that
+  the directly monadic formulation of such their type
+  would necessarily make things slower. This appears to be a prejudice.
+  For example, passing a large file of short lines through
+  this benchmark transformation
+  .
+  > Lazy.unlines      . map    (\bs -> "!"       <> Lazy.drop 5 bs)       . Lazy.lines
+  > Streaming.unlines . S.maps (\bs -> chunk "!" >> Streaming.drop 5 bs)  . Streaming.lines
+  .
+  gives pleasing results like these
+  .
+  > $  time ./benchlines lazy >> /dev/null
+  > real	0m2.097s
+  > ...
+  > $  time ./benchlines streaming >> /dev/null
+  > real	0m1.930s
+  .
+  For a more sophisticated operation like
+  .
+  > Lazy.intercalate "!\n"      . Lazy.lines
+  > Streaming.intercalate "!\n" . Streaming.lines
+  .
+  we get results like these:
+  .
+  > time ./benchlines lazy >> /dev/null
+  > real	0m1.250s
+  > ...
+  > time ./benchlines streaming >> /dev/null
+  > real	0m1.531s
+  .
+  The pipes environment would express the latter as
+  .
+  > Pipes.intercalates (Pipes.yield "!\n") . view Pipes.lines
+  .
+  meaning almost exactly what we mean above, but with results like this
+  .
+  >  time ./benchlines pipes >> /dev/null
+  >  real	0m6.353s
+  .
+  The difference, however, /is emphatically not intrinsic to pipes/;
+  it is just that
+  this library depends the @streaming@ library, which is used in place
+  of @free@ to express the
+  <http://www.haskellforall.com/2013/09/perfect-streaming-using-pipes-bytestring.html "perfectly streaming">
+  splitting and iterated division or "chunking" of byte streams.
+  .
+  These concepts belong to the ABCs of streaming; @lines@ is just
+  a textbook example, and it is of course handled correctly in
+  @Data.ByteString.Lazy@.
+  But the concepts are /catastrophically mishandled/ in /all/ streaming io libraries
+  other than pipes. Already the @enumerator@ and @iteratee@ libraries
+  were completely defeated by @lines@:
+  see e.g. the @enumerator@ implementation of
+  <http://hackage.haskell.org/package/enumerator-0.4.20/docs/Data-Enumerator-Text.html#v:splitWhen splitWhen and lines>.
+  This will concatenate strict text forever, if that's what is coming
+  in.  The rot spreads from there.
+  It is just a fact that in all of the general streaming io
+  frameworks other than pipes,it becomes torture to express elementary distinctions
+  that are transparently and immediately contained in any
+  idea of streaming whatsoever.
+  .
+  Though, as was said above, we barely alter signatures in @Data.ByteString.Lazy@
+  more than is required by the types, the point of view that emerges
+  is very much that of
+  @pipes-bytestring@ and @pipes-group@. In particular
+  we have these correspondences:
+  .
+  > Lazy.splitAt      :: Int -> ByteString              -> (ByteString, ByteString)
+  > Streaming.splitAt :: Int -> ByteString m r          -> ByteString m (ByteString m r)
+  > Pipes.splitAt     :: Int -> Producer ByteString m r -> Producer ByteString m (Producer ByteString m r)
+  .
+  and
+  .
+  > Lazy.lines      :: ByteString -> [ByteString]
+  > Streaming.lines :: ByteString m r -> Stream (ByteString m) m r
+  > Pipes.lines     :: Producer ByteString m r -> FreeT (Producer ByteString m) m r
+  .
+  where the @Stream@ type expresses the sequencing of @ByteString m _@ layers
+  with the usual \'free monad\' sequencing.
+  .
+  Interoperation with @pipes-bytestring@ uses this isomorphism:
+  .
+  > Streaming.ByteString.unfoldrChunks Pipes.next :: Monad m => Producer ByteString m r -> ByteString m r
+  > Pipes.unfoldr Streaming.ByteString.nextChunk  :: Monad m => ByteString m r -> Producer ByteString m r
+  .
+  Interoperation with @io-streams@ is thus:
+  .
+  > IOStreams.unfoldM Streaming.ByteString.unconsChunk :: ByteString IO () -> IO (InputStream ByteString)
+  > Streaming.ByteString.reread IOStreams.read         :: InputStream ByteString -> ByteString IO ()
+  .
+  and similarly for other rational streaming io libraries.
+  .
+  Problems and questions about the library can be put as issues on
+  the github page, or mailed to the
+  <https://groups.google.com/forum/#!forum/haskell-pipes pipes list>.
+  .
+  A tutorial module is in the works;
+  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>,
+  for the moment,
+  is a sequence of simplified implementations of familiar shell utilities.
+  The same programs are implemented at the end of the excellent
+  <http://hackage.haskell.org/package/io-streams-1.3.2.0/docs/System-IO-Streams-Tutorial.html io-streams tutorial>.
+  It is generally much simpler; in some case simpler than what
+  you would write with lazy bytestrings.
+  <https://gist.github.com/michaelt/2dcea1ba32562c091357 Here>
+  is a simple GET request that returns a byte stream.
+  .
 
-description:         This is an implementation of effectful, memory-constrained
-                     bytestrings (byte streams) and functions for streaming
-                     bytestring manipulation, adequate for non-lazy-io.
-                     Some examples of the use of byte streams to implement simple
-                     shell progams can be found
-                     <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>.
-                     See also the illustrations of use with e.g. @attoparsec@,
-                     @aeson@, @http-client@, @zlib@ etc. in the
-                     <https://hackage.haskell.org/package/streaming-utils streaming-utils>
-                     library.  Usage is as close as possible to that of @ByteString@
-                     and lazy @ByteString@.
-                     .
-                     A @ByteString IO ()@ is the most natural representation of
-                     an effectful stream of bytes arising chunkwise from a handle.
-                     Indeed, the implementation follows the
-                     details of @Data.ByteString.Lazy@ and @Data.ByteString.Lazy.Char8@
-                     in unrelenting detail, omitting only transparently non-streaming
-                     operations like @reverse@. It is just a question of replacing
-                     the lazy bytestring type:
-                     .
-                     > data ByteString     = Empty   | Chunk Strict.ByteString ByteString
-                     .
-                     with the /minimal/ effectful variant:
-                     .
-                     > data ByteString m r = Empty r | Chunk Strict.ByteString (ByteString m r) | Go (m (ByteString m r))
-                     .
-                     (Constructors are necessarily hidden in internal modules in both the @Lazy@ and the @Streaming@.)
-                     .
-                     That's it. As a lazy bytestring is implemented internally
-                     by a sort of list of strict bytestring chunks, a streaming bytestring is
-                     simply implemented as a /producer/ or /generator/ of strict bytestring chunks.
-                     Most operations are defined by simply adding a line to what we find in
-                     @Data.ByteString.Lazy@. The only possible simplification would
-                     involve specializing to @IO@, throughout - but this would e.g. block
-                     the use of @ResourceT@ to manage handles and the like, and a number
-                     of other convenient operations like @copy@, which permits one to
-                     apply two operations simultaneously over the length of the byte stream.
-                     .
-                     Something like this alteration of type is of course obvious and mechanical, once the idea of
-                     an effectful bytestring type is contemplated and lazy io is rejected.
-                     Indeed it seems that this is the proper expression of what was
-                     intended by lazy bytestrings to begin with. The documentation, after all,
-                     reads
-                     .
-                     * \"A key feature of lazy ByteStrings is the means to manipulate large or
-                       unbounded streams of data without requiring the entire sequence to be
-                       resident in memory. To take advantage of this you have to write your
-                       functions in a lazy streaming style, e.g. classic pipeline composition.
-                       The default I/O chunk size is 32k, which should be good in most circumstances.\"
-                     .
-                     ... which is very much the idea of this library: the default chunk size for
-                     'hGetContents' and the like follows @Data.ByteString.Lazy@; operations
-                     like @lines@ and @append@ and so on are tailored not to increase chunk size.
-                     .
-                     The present library is thus if you like nothing but /lazy bytestring done right/.
-                     The authors of @Data.ByteString.Lazy@ must have supposed that
-                     the directly monadic formulation of such their type
-                     would necessarily make things slower. This appears to be a prejudice.
-                     For example, passing a large file of short lines through
-                     this benchmark transformation
-                     .
-                     > Lazy.unlines      . map    (\bs -> "!"       <> Lazy.drop 5 bs)       . Lazy.lines
-                     > Streaming.unlines . S.maps (\bs -> chunk "!" >> Streaming.drop 5 bs)  . Streaming.lines
-                     .
-                     gives pleasing results like these
-                     .
-                     > $  time ./benchlines lazy >> /dev/null
-                     > real	0m2.097s
-                     > ...
-                     > $  time ./benchlines streaming >> /dev/null
-                     > real	0m1.930s
-                     .
-                     For a more sophisticated operation like
-                     .
-                     > Lazy.intercalate "!\n"      . Lazy.lines
-                     > Streaming.intercalate "!\n" . Streaming.lines
-                     .
-                     we get results like these:
-                     .
-                     > time ./benchlines lazy >> /dev/null
-                     > real	0m1.250s
-                     > ...
-                     > time ./benchlines streaming >> /dev/null
-                     > real	0m1.531s
-                     .
-                     The pipes environment would express the latter as
-                     .
-                     > Pipes.intercalates (Pipes.yield "!\n") . view Pipes.lines
-                     .
-                     meaning almost exactly what we mean above, but with results like this
-                     .
-                     >  time ./benchlines pipes >> /dev/null
-                     >  real	0m6.353s
-                     .
-                     The difference, however, /is emphatically not intrinsic to pipes/;
-                     it is just that
-                     this library depends the @streaming@ library, which is used in place
-                     of @free@ to express the
-                     <http://www.haskellforall.com/2013/09/perfect-streaming-using-pipes-bytestring.html "perfectly streaming">
-                     splitting and iterated division or "chunking" of byte streams.
-                     .
-                     These concepts belong to the ABCs of streaming; @lines@ is just
-                     a textbook example, and it is of course handled correctly in
-                     @Data.ByteString.Lazy@.
-                     But the concepts are /catastrophically mishandled/ in /all/ streaming io libraries
-                     other than pipes. Already the @enumerator@ and @iteratee@ libraries
-                     were completely defeated by @lines@:
-                     see e.g. the @enumerator@ implementation of
-                     <http://hackage.haskell.org/package/enumerator-0.4.20/docs/Data-Enumerator-Text.html#v:splitWhen splitWhen and lines>.
-                     This will concatenate strict text forever, if that's what is coming
-                     in.  The rot spreads from there.
-                     It is just a fact that in all of the general streaming io
-                     frameworks other than pipes,it becomes torture to express elementary distinctions
-                     that are transparently and immediately contained in any
-                     idea of streaming whatsoever.
-                     .
-                     Though, as was said above, we barely alter signatures in @Data.ByteString.Lazy@
-                     more than is required by the types, the point of view that emerges
-                     is very much that of
-                     @pipes-bytestring@ and @pipes-group@. In particular
-                     we have these correspondences:
-                     .
-                     > Lazy.splitAt      :: Int -> ByteString              -> (ByteString, ByteString)
-                     > Streaming.splitAt :: Int -> ByteString m r          -> ByteString m (ByteString m r)
-                     > Pipes.splitAt     :: Int -> Producer ByteString m r -> Producer ByteString m (Producer ByteString m r)
-                     .
-                     and
-                     .
-                     > Lazy.lines      :: ByteString -> [ByteString]
-                     > Streaming.lines :: ByteString m r -> Stream (ByteString m) m r
-                     > Pipes.lines     :: Producer ByteString m r -> FreeT (Producer ByteString m) m r
-                     .
-                     where the @Stream@ type expresses the sequencing of @ByteString m _@ layers
-                     with the usual \'free monad\' sequencing.
-                     .
-                     Interoperation with @pipes-bytestring@ uses this isomorphism:
-                     .
-                     > Streaming.ByteString.unfoldrChunks Pipes.next :: Monad m => Producer ByteString m r -> ByteString m r
-                     > Pipes.unfoldr Streaming.ByteString.nextChunk  :: Monad m => ByteString m r -> Producer ByteString m r
-                     .
-                     Interoperation with @io-streams@ is thus:
-                     .
-                     > IOStreams.unfoldM Streaming.ByteString.unconsChunk :: ByteString IO () -> IO (InputStream ByteString)
-                     > Streaming.ByteString.reread IOStreams.read         :: InputStream ByteString -> ByteString IO ()
-                     .
-                     and similarly for other rational streaming io libraries.
-                     .
-                     Problems and questions about the library can be put as issues on
-                     the github page, or mailed to the
-                     <https://groups.google.com/forum/#!forum/haskell-pipes pipes list>.
-                     .
-                     A tutorial module is in the works;
-                     <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>,
-                     for the moment,
-                     is a sequence of simplified implementations of familiar shell utilities.
-                     The same programs are implemented at the end of the excellent
-                       <http://hackage.haskell.org/package/io-streams-1.3.2.0/docs/System-IO-Streams-Tutorial.html io-streams tutorial>.
-                       It is generally much simpler; in some case simpler than what
-                       you would write with lazy bytestrings.
-                       <https://gist.github.com/michaelt/2dcea1ba32562c091357 Here>
-                       is a simple GET request that returns a byte stream.
-                       .
+license:            BSD3
+license-file:       LICENSE
+author:             michaelt
+maintainer:
+  andrew.thaddeus@gmail.com, what_is_it_to_do_anything@yahoo.com
 
-
-license:             BSD3
-license-file:        LICENSE
-author:              michaelt
-maintainer:          andrew.thaddeus@gmail.com, what_is_it_to_do_anything@yahoo.com
 -- copyright:
-category:            Data, Pipes, Streaming
-build-type:          Simple
-extra-source-files:  README.md, CHANGELOG.md, tests/sample.txt
-cabal-version:       >=1.10
-stability:           Experimental
-homepage:            https://github.com/haskell-streaming/streaming-bytestring
-bug-reports:         https://github.com/haskell-streaming/streaming-bytestring/issues
-tested-with: GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.8.4, GHC==8.10.1
+category:           Data, Pipes, Streaming
+build-type:         Simple
+extra-source-files:
+  README.md
+  CHANGELOG.md
+  tests/sample.txt
+
+stability:          Experimental
+homepage:           https://github.com/haskell-streaming/streaming-bytestring
+bug-reports:
+  https://github.com/haskell-streaming/streaming-bytestring/issues
+
+tested-with:
+  GHC ==7.10.3
+   || ==8.0.2
+   || ==8.2.2
+   || ==8.4.4
+   || ==8.6.5
+   || ==8.8.4
+   || ==8.10.2
 
 source-repository head
-    type: git
-    location: https://github.com/michaelt/streaming-bytestring
-
+  type:     git
+  location: https://github.com/michaelt/streaming-bytestring
 
 library
-  exposed-modules:     Data.ByteString.Streaming
-                       , Data.ByteString.Streaming.Char8
-                       , Data.ByteString.Streaming.Internal
-
+  default-language: Haskell2010
+  ghc-options:      -Wall -O2
+  exposed-modules:
+    Data.ByteString.Streaming
+    Data.ByteString.Streaming.Char8
+    Data.ByteString.Streaming.Internal
 
   -- other-modules:
-  other-extensions:    CPP, BangPatterns, ForeignFunctionInterface, DeriveDataTypeable, Unsafe
-  build-depends:       base  >=4.8 && <5.0
-                     , bytestring
-                     , deepseq
-                     , exceptions
-                     , mmorph >=1.0 && <1.2
-                     , mtl >=2.1 && <2.3
-                     , resourcet
-                     , transformers >=0.3 && <0.6
-                     , transformers-base
-                     , streaming >=  0.1.4.0 && < 0.3
-  if impl(ghc < 7.8)
-    build-depends: bytestring < 0.10.4.0
-                 , bytestring-builder
-  else
-    if impl(ghc < 8.0)
-      build-depends: bytestring >= 0.10.4 && < 0.11
-    else
-      build-depends: bytestring >= 0.10.4 && < 0.12
+  other-extensions:
+    BangPatterns
+    CPP
+    DeriveDataTypeable
+    ForeignFunctionInterface
+    Unsafe
 
-  if impl(ghc < 8.0)
+  build-depends:
+      base               >=4.8     && <5.0
+    , bytestring
+    , deepseq
+    , exceptions
+    , mmorph             >=1.0     && <1.2
+    , mtl                >=2.1     && <2.3
+    , resourcet
+    , streaming          >=0.1.4.0 && <0.3
+    , transformers       >=0.3     && <0.6
+    , transformers-base
+
+  if impl(ghc <7.8)
+    build-depends:
+        bytestring          >=0 && <0.10.4.0
+      , bytestring-builder
+
+  else
+    if impl(ghc <8.0)
+      build-depends: bytestring >=0.10.4 && <0.11
+
+    else
+      build-depends: bytestring >=0.10.4 && <0.12
+
+  if impl(ghc <8.0)
     build-depends: semigroups
 
-  default-language:    Haskell2010
-  ghc-options: -O2
-
 test-suite test
-  default-language:
-    Haskell2010
-  type:
-    exitcode-stdio-1.0
-  hs-source-dirs:
-    tests
-  main-is:
-    Test.hs
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests
+  main-is:          Test.hs
   build-depends:
-      base >= 4 && < 5
-    , transformers
-    , tasty >= 0.11.0.4
-    , tasty-smallcheck >= 0.8.1
-    , tasty-hunit >= 0.9
-    , smallcheck >= 1.1.1
+      base                  >=4        && <5
+    , bytestring
+    , smallcheck            >=1.1.1
     , streaming
     , streaming-bytestring
-    , bytestring
+    , tasty                 >=0.11.0.4
+    , tasty-hunit           >=0.9
+    , tasty-smallcheck      >=0.8.1
+    , transformers

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -165,6 +165,7 @@ extra-source-files:
   README.md
   CHANGELOG.md
   tests/sample.txt
+  tests/groupBy.txt
 
 stability:          Experimental
 homepage:           https://github.com/haskell-streaming/streaming-bytestring

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -3,25 +3,20 @@ name:               streaming-bytestring
 version:            0.1.6
 synopsis:           effectful byte steams, or: bytestring io done right.
 description:
-  This is an implementation of effectful, memory-constrained
-  bytestrings (byte streams) and functions for streaming
-  bytestring manipulation, adequate for non-lazy-io.
-  Some examples of the use of byte streams to implement simple
+  This is an implementation of effectful, memory-constrained bytestrings (byte
+  streams) and functions for streaming bytestring manipulation, adequate for
+  non-lazy-io. Some examples of the use of byte streams to implement simple
   shell progams can be found
-  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>.
-  See also the illustrations of use with e.g. @attoparsec@,
-  @aeson@, @http-client@, @zlib@ etc. in the
-  <https://hackage.haskell.org/package/streaming-utils streaming-utils>
-  library.  Usage is as close as possible to that of @ByteString@
-  and lazy @ByteString@.
+  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>. See also the
+  illustrations of use with e.g. @attoparsec@, @aeson@, @http-client@, @zlib@
+  etc. in the <https://hackage.haskell.org/package/streaming-utils streaming-utils>
+  library. Usage is as close as possible to that of @ByteString@ and lazy @ByteString@.
   .
-  A @ByteString IO ()@ is the most natural representation of
-  an effectful stream of bytes arising chunkwise from a handle.
-  Indeed, the implementation follows the
-  details of @Data.ByteString.Lazy@ and @Data.ByteString.Lazy.Char8@
-  in unrelenting detail, omitting only transparently non-streaming
-  operations like @reverse@. It is just a question of replacing
-  the lazy bytestring type:
+  A @ByteString IO ()@ is the most natural representation of an effectful stream
+  of bytes arising chunkwise from a handle. Indeed, the implementation follows
+  the details of @Data.ByteString.Lazy@ and @Data.ByteString.Lazy.Char8@ in
+  unrelenting detail, omitting only transparently non-streaming operations like
+  @reverse@. It is just a question of replacing the lazy bytestring type:
   .
   > data ByteString     = Empty   | Chunk Strict.ByteString ByteString
   .
@@ -31,38 +26,36 @@ description:
   .
   (Constructors are necessarily hidden in internal modules in both the @Lazy@ and the @Streaming@.)
   .
-  That's it. As a lazy bytestring is implemented internally
-  by a sort of list of strict bytestring chunks, a streaming bytestring is
-  simply implemented as a /producer/ or /generator/ of strict bytestring chunks.
-  Most operations are defined by simply adding a line to what we find in
-  @Data.ByteString.Lazy@. The only possible simplification would
-  involve specializing to @IO@, throughout - but this would e.g. block
-  the use of @ResourceT@ to manage handles and the like, and a number
-  of other convenient operations like @copy@, which permits one to
-  apply two operations simultaneously over the length of the byte stream.
+  That's it. As a lazy bytestring is implemented internally by a sort of list of
+  strict bytestring chunks, a streaming bytestring is simply implemented as a
+  /producer/ or /generator/ of strict bytestring chunks. Most operations are
+  defined by simply adding a line to what we find in @Data.ByteString.Lazy@. The
+  only possible simplification would involve specializing to @IO@, throughout -
+  but this would e.g. block the use of @ResourceT@ to manage handles and the
+  like, and a number of other convenient operations like @copy@, which permits
+  one to apply two operations simultaneously over the length of the byte stream.
   .
-  Something like this alteration of type is of course obvious and mechanical, once the idea of
-  an effectful bytestring type is contemplated and lazy io is rejected.
-  Indeed it seems that this is the proper expression of what was
+  Something like this alteration of type is of course obvious and mechanical,
+  once the idea of an effectful bytestring type is contemplated and lazy io is
+  rejected. Indeed it seems that this is the proper expression of what was
   intended by lazy bytestrings to begin with. The documentation, after all,
   reads
   .
   * \"A key feature of lazy ByteStrings is the means to manipulate large or
-  unbounded streams of data without requiring the entire sequence to be
-  resident in memory. To take advantage of this you have to write your
-  functions in a lazy streaming style, e.g. classic pipeline composition.
-  The default I/O chunk size is 32k, which should be good in most circumstances.\"
+  unbounded streams of data without requiring the entire sequence to be resident
+  in memory. To take advantage of this you have to write your functions in a
+  lazy streaming style, e.g. classic pipeline composition. The default I/O chunk
+  size is 32k, which should be good in most circumstances.\"
   .
   ... which is very much the idea of this library: the default chunk size for
-  'hGetContents' and the like follows @Data.ByteString.Lazy@; operations
-  like @lines@ and @append@ and so on are tailored not to increase chunk size.
+  'hGetContents' and the like follows @Data.ByteString.Lazy@; operations like
+  @lines@ and @append@ and so on are tailored not to increase chunk size.
   .
-  The present library is thus if you like nothing but /lazy bytestring done right/.
-  The authors of @Data.ByteString.Lazy@ must have supposed that
-  the directly monadic formulation of such their type
-  would necessarily make things slower. This appears to be a prejudice.
-  For example, passing a large file of short lines through
-  this benchmark transformation
+  The present library is thus if you like nothing but /lazy bytestring done
+  right/. The authors of @Data.ByteString.Lazy@ must have supposed that the
+  directly monadic formulation of such their type would necessarily make things
+  slower. This appears to be a prejudice. For example, passing a large file of
+  short lines through this benchmark transformation
   .
   > Lazy.unlines      . map    (\bs -> "!"       <> Lazy.drop 5 bs)       . Lazy.lines
   > Streaming.unlines . S.maps (\bs -> chunk "!" >> Streaming.drop 5 bs)  . Streaming.lines
@@ -97,33 +90,29 @@ description:
   >  time ./benchlines pipes >> /dev/null
   >  real	0m6.353s
   .
-  The difference, however, /is emphatically not intrinsic to pipes/;
-  it is just that
-  this library depends the @streaming@ library, which is used in place
-  of @free@ to express the
+  The difference, however, /is emphatically not intrinsic to pipes/; it is just
+  that this library depends the @streaming@ library, which is used in place of
+  @free@ to express the
   <http://www.haskellforall.com/2013/09/perfect-streaming-using-pipes-bytestring.html "perfectly streaming">
   splitting and iterated division or "chunking" of byte streams.
   .
-  These concepts belong to the ABCs of streaming; @lines@ is just
-  a textbook example, and it is of course handled correctly in
-  @Data.ByteString.Lazy@.
-  But the concepts are /catastrophically mishandled/ in /all/ streaming io libraries
-  other than pipes. Already the @enumerator@ and @iteratee@ libraries
-  were completely defeated by @lines@:
-  see e.g. the @enumerator@ implementation of
+  These concepts belong to the ABCs of streaming; @lines@ is just a textbook
+  example, and it is of course handled correctly in @Data.ByteString.Lazy@. But
+  the concepts are /catastrophically mishandled/ in /all/ streaming io libraries
+  other than pipes. Already the @enumerator@ and @iteratee@ libraries were
+  completely defeated by @lines@: see e.g. the @enumerator@ implementation of
   <http://hackage.haskell.org/package/enumerator-0.4.20/docs/Data-Enumerator-Text.html#v:splitWhen splitWhen and lines>.
-  This will concatenate strict text forever, if that's what is coming
-  in.  The rot spreads from there.
-  It is just a fact that in all of the general streaming io
-  frameworks other than pipes,it becomes torture to express elementary distinctions
-  that are transparently and immediately contained in any
-  idea of streaming whatsoever.
   .
-  Though, as was said above, we barely alter signatures in @Data.ByteString.Lazy@
-  more than is required by the types, the point of view that emerges
-  is very much that of
-  @pipes-bytestring@ and @pipes-group@. In particular
-  we have these correspondences:
+  This will concatenate strict text forever, if that's what is coming in. The
+  rot spreads from there. It is just a fact that in all of the general streaming
+  io frameworks other than pipes,it becomes torture to express elementary
+  distinctions that are transparently and immediately contained in any idea of
+  streaming whatsoever.
+  .
+  Though, as was said above, we barely alter signatures in
+  @Data.ByteString.Lazy@ more than is required by the types, the point of view
+  that emerges is very much that of @pipes-bytestring@ and @pipes-group@. In
+  particular we have these correspondences:
   .
   > Lazy.splitAt      :: Int -> ByteString              -> (ByteString, ByteString)
   > Streaming.splitAt :: Int -> ByteString m r          -> ByteString m (ByteString m r)
@@ -150,19 +139,16 @@ description:
   .
   and similarly for other rational streaming io libraries.
   .
-  Problems and questions about the library can be put as issues on
-  the github page, or mailed to the
-  <https://groups.google.com/forum/#!forum/haskell-pipes pipes list>.
+  Problems and questions about the library can be put as issues on the github
+  page, or mailed to the <https://groups.google.com/forum/#!forum/haskell-pipes pipes list>.
   .
   A tutorial module is in the works;
-  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>,
-  for the moment,
-  is a sequence of simplified implementations of familiar shell utilities.
-  The same programs are implemented at the end of the excellent
+  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>, for the moment,
+  is a sequence of simplified implementations of familiar shell utilities. The
+  same programs are implemented at the end of the excellent
   <http://hackage.haskell.org/package/io-streams-1.3.2.0/docs/System-IO-Streams-Tutorial.html io-streams tutorial>.
-  It is generally much simpler; in some case simpler than what
-  you would write with lazy bytestrings.
-  <https://gist.github.com/michaelt/2dcea1ba32562c091357 Here>
+  It is generally much simpler; in some case simpler than what you would write
+  with lazy bytestrings. <https://gist.github.com/michaelt/2dcea1ba32562c091357 Here>
   is a simple GET request that returns a byte stream.
   .
 
@@ -170,7 +156,7 @@ license:            BSD3
 license-file:       LICENSE
 author:             michaelt
 maintainer:
-  andrew.thaddeus@gmail.com, what_is_it_to_do_anything@yahoo.com
+  andrew.thaddeus@gmail.com, what_is_it_to_do_anything@yahoo.com, colin@fosskers.ca
 
 -- copyright:
 category:           Data, Pipes, Streaming

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -235,6 +235,7 @@ test-suite test
   build-depends:
       base                  >=4        && <5
     , bytestring
+    , resourcet             >=1.2
     , smallcheck            >=1.1.1
     , streaming
     , streaming-bytestring

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -235,7 +235,7 @@ test-suite test
   build-depends:
       base                  >=4        && <5
     , bytestring
-    , resourcet             >=1.2
+    , resourcet             >=1.1
     , smallcheck            >=1.1.1
     , streaming
     , streaming-bytestring

--- a/tests/groupBy.txt
+++ b/tests/groupBy.txt
@@ -1,0 +1,572 @@
+This is a test file, larger than 32kb, which is designed to trigger a (hopefully
+now fixed) bug in `group` and `groupBy`. Well, here goes.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.


### PR DESCRIPTION
This PR clears out a number of warnings, and improves code formatting in a number of places. Further, it solves a critical bug found in `group` and `groupBy`.