### PR TITLE
Github CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -35,10 +35,10 @@ jobs:
           enable-stack: true
 
       - name: Clone project
-        uses: actions/checkout@v2.1
+        uses: actions/checkout@v2.1.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2.1
+        uses: actions/cache@v2.1.1
         with:
           path: ~/.stack
           key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}

--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -1,0 +1,50 @@
+name: Tests
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: CI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        resolver: ['lts-16.14', 'lts-14.27', 'lts-12.26', 'lts-11.22', 'lts-9.21', 'lts-6.35']
+        include:
+        - resolver: 'lts-16.14'
+          ghc: '8.8.4'
+        - resolver: 'lts-14.27'
+          ghc: '8.6.5'
+        - resolver: 'lts-12.26'
+          ghc: '8.4.4'
+        - resolver: 'lts-11.22'
+          ghc: '8.2.2'
+        - resolver: 'lts-9.21'
+          ghc: '8.0.2'
+        - resolver: 'lts-6.35'
+          ghc: '7.10.3'
+
+    steps:
+      - name: Setup GHC
+        uses: actions/setup-haskell@v1.1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+
+      - name: Clone project
+        uses: actions/checkout@v2.1
+
+      - name: Cache dependencies
+        uses: actions/cache@v2.1
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.resolver }}-
+
+      # This entirely avoids the caching of a GHC version.
+      - name: Build and run tests
+        run: 'stack test --fast --no-terminal --resolver=${{ matrix.resolver }} --system-ghc'

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -232,7 +232,7 @@ test-suite test
     , transformers
     , tasty >= 0.11.0.4
     , tasty-smallcheck >= 0.8.1
-    , tasty-hunit >= 0.10
+    , tasty-hunit >= 0.9
     , smallcheck >= 1.1.1
     , streaming
     , streaming-bytestring


### PR DESCRIPTION
This PR supplements the Travis/Cabal-based CI with Github/Stack-based config. Since the `streaming-*` libraries are on Stackage and many people use them from there (myself included), this seems like a good thing to test. Further, since the builds are performed directly by Github, it's easy to see the results.

Points of note:
- This tests builds of `streaming-bytestring` with LTS versions that correspond to the "tested GHC versions" claimed in our `.cabal`. 
- The `setup-haskell` action contains `stack` and `ghc`, so we don't need to cache a custom `ghc` download. Hence, `--system-ghc` is passed to stack.
- If we add this, it will also help me debug https://github.com/haskell-streaming/streaming-bytestring/pull/22 .

If we are happy with the additions (and how it performs), we could consider moving the Cabal-based tests to Github as well, since it's usually faster than Travis, allows more concurrent builds, and has clearer results.