### PR TITLE
`groupBy` char ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@
 
 - An incorrect comment about `Handle`s being automatically closed upon EOF with
   `hGetContents` and `hGetContentsN`. [#9]
-- A critical bug in `group` and `groupBy` that would crash code when reading
-  enough bytes. [#22]
+- A crash in `group` and `groupBy` when reading too many bytes. [#22]
+- `groupBy` incorrectly ordering its output elements. [#4]
 
 [#9]: https://github.com/haskell-streaming/streaming-bytestring/issues/9
 [#18]: https://github.com/haskell-streaming/streaming-bytestring/pull/18
 [#22]: https://github.com/haskell-streaming/streaming-bytestring/pull/22
+[#4]: https://github.com/haskell-streaming/streaming-bytestring/issues/4
 
 ## 0.1.6
 

--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -1665,19 +1665,6 @@ revNonEmptyChunks = Prelude.foldr (\bs f -> Chunk bs . f) id
 revChunks :: Monad m => [P.ByteString] -> r -> ByteString m r
 revChunks cs r = L.foldl' (flip Chunk) (Empty r) cs
 {-# INLINE revChunks #-}
--- | 'findIndexOrEnd' is a variant of findIndex, that returns the length
--- of the string if no element is found, rather than Nothing.
-findIndexOrEnd :: (Word8 -> Bool) -> P.ByteString -> Int
-findIndexOrEnd k (B.PS x s l) =
-    B.accursedUnutterablePerformIO $
-      withForeignPtr x $ \f -> go (f `plusPtr` s) 0
-  where
-    go !ptr !n | n >= l    = return l
-               | otherwise = do w <- peek ptr
-                                if k w
-                                  then return n
-                                  else go (ptr `plusPtr` 1) (n+1)
-{-# INLINABLE findIndexOrEnd #-}
 
 zipWithStream
   :: (Monad m)

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -86,12 +86,22 @@ groupCharOrder = do
 
 groupByCharOrder :: Assertion
 groupByCharOrder = do
+  -- What about when everything fits into one group?
+  y <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\_ _ -> True) $ Q8.fromLazy @IO "abcd"
+  y @?= ["abcd"]
+  -- Prove it's not an issue with the Char-based wrapper.
   z <- S.toList_ . SM.mapsM Q.toLazy $ Q.groupBy (\a b -> a - 1 == b) $ Q.fromLazy @IO "98764321"
   z @?= ["98", "76", "43", "21"]
+  -- Char-based variant
   a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\a b -> succ a == b) $ Q8.fromLazy @IO "12346789"
   a @?= ["12", "34", "67", "89"]
   b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (on (==) (== '5')) $ Q8.fromLazy @IO "5678"
-  b @?= ["5", "6", "7", "8"]
+  b @?= ["5", "678"]
+
+goodFindIndex :: Assertion
+goodFindIndex = do
+  assertBool "Expected the length of the string" $ QI.findIndexOrEnd (const False) "1234" == 4
+  assertBool "Expected 0" $ QI.findIndexOrEnd (const True) "1234" == 0
 
 main :: IO ()
 main = defaultMain $ testGroup "Tests"
@@ -125,5 +135,6 @@ main = defaultMain $ testGroup "Tests"
     , testCase "group(By): Don't crash" groupCrash
     , testCase "group: Char order" groupCharOrder
     , testCase "groupBy: Char order" groupByCharOrder
+    , testCase "findIndexOrEnd" goodFindIndex
     ]
   ]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
 module Main ( main ) where
 
 import           Control.Monad.Trans.Resource (runResourceT)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Streaming.Char8 as SBS8
-import qualified Data.ByteString.Streaming.Internal as SBSI
+import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.Streaming as Q
+import qualified Data.ByteString.Streaming.Char8 as Q8
+import qualified Data.ByteString.Streaming.Internal as QI
+import           Data.Function (on)
 import           Data.Functor.Identity
 import qualified Data.List as L
 import           Data.String (fromString)
@@ -32,74 +38,92 @@ chunksSeries = listOf strSeries
 nats :: Monad m => Series m Int
 nats = generate $ \d -> [1..d]
 
-fromChunks :: [String] -> SBS8.ByteString Identity ()
-fromChunks = SBS8.fromChunks . S.each .  map BS8.pack
+fromChunks :: [String] -> Q8.ByteString Identity ()
+fromChunks = Q8.fromChunks . S.each .  map B.pack
 
 unix2dos :: String -> String
 unix2dos = concatMap $ \c -> if c == '\n' then "\r\n" else [c]
 
-unpackToString :: SBS8.ByteString Identity () -> String
-unpackToString = runIdentity . S.toList_ . SBS8.unpack
+unpackToString :: Q8.ByteString Identity () -> String
+unpackToString = runIdentity . S.toList_ . Q8.unpack
 
-sLines :: SBS8.ByteString Identity () -> [BS8.ByteString]
+sLines :: Q8.ByteString Identity () -> [B.ByteString]
 sLines
   = runIdentity
   . S.toList_
-  . S.mapped SBS8.toStrict
-  . SBS8.lines
+  . S.mapped Q8.toStrict
+  . Q8.lines
 
-noNullChunks :: S.Stream (SBS8.ByteString Identity) Identity () -> Bool
+noNullChunks :: S.Stream (Q8.ByteString Identity) Identity () -> Bool
 noNullChunks = SM.streamFold (\() -> True) runIdentity go
   where
-  go :: SBS8.ByteString Identity Bool -> Bool
-  go (SBSI.Empty b)           = b
-  go (SBSI.Chunk bs sbs)      = not (BS8.null bs) && go sbs
-  go (SBSI.Go (Identity sbs)) = go sbs
+    go :: Q8.ByteString Identity Bool -> Bool
+    go (QI.Empty b)           = b
+    go (QI.Chunk bs sbs)      = not (B.null bs) && go sbs
+    go (QI.Go (Identity sbs)) = go sbs
 
 handleIsOpen :: Assertion
 handleIsOpen = do
   h <- openBinaryFile "tests/sample.txt" ReadMode
   hIsOpen h >>= assertBool "Expected file handle to be open!"
-  l <- SBS8.length_ $ SBS8.hGetContents h
+  l <- Q8.length_ $ Q8.hGetContents h
   l @?= 73
   hIsOpen h >>= assertBool "Still expected file handle to be open!"
 
 groupCrash :: Assertion
 groupCrash = do
-  a <- runResourceT . S.sum_ . SM.mapsM SBS8.length . SBS8.group $ SBS8.readFile "tests/groupBy.txt"
+  a <- runResourceT . S.sum_ . SM.mapsM Q8.length . Q8.group $ Q8.readFile "tests/groupBy.txt"
   a @?= 39925
-  b <- runResourceT . S.sum_ . SM.mapsM SBS8.length . SBS8.groupBy (\_ _ -> True) $ SBS8.readFile "tests/groupBy.txt"
+  b <- runResourceT . S.sum_ . SM.mapsM Q8.length . Q8.groupBy (\_ _ -> True) $ Q8.readFile "tests/groupBy.txt"
   b @?= 39925
+
+groupCharOrder :: Assertion
+groupCharOrder = do
+  a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.group $ Q8.fromLazy @IO "1234"
+  a @?= (["1", "2", "3", "4"] :: [BL.ByteString])
+  b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.group $ Q8.fromLazy @IO "1122"
+  b @?= (["11", "22"] :: [BL.ByteString])
+
+groupByCharOrder :: Assertion
+groupByCharOrder = do
+  z <- S.toList_ . SM.mapsM Q.toLazy $ Q.groupBy (\a b -> a - 1 == b) $ Q.fromLazy @IO "98764321"
+  z @?= ["98", "76", "43", "21"]
+  a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\a b -> succ a == b) $ Q8.fromLazy @IO "12346789"
+  a @?= ["12", "34", "67", "89"]
+  b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (on (==) (== '5')) $ Q8.fromLazy @IO "5678"
+  b @?= ["5", "6", "7", "8"]
 
 main :: IO ()
 main = defaultMain $ testGroup "Tests"
-  [ testGroup "lines"
+  [ testGroup "Property Tests"
     [ testProperty "Data.ByteString.Streaming.Char8.lines is equivalent to Prelude.lines" $ over chunksSeries $ \chunks ->
         -- This only makes sure that the streaming-bytestring lines function
         -- matches the Prelude lines function when no carriage returns
         -- are present. They are not expected to have the same behavior
         -- with dos-style line termination.
         let expected = lines $ concat chunks
-            got = (map BS8.unpack . sLines . fromChunks) chunks
+            got = (map B.unpack . sLines . fromChunks) chunks
         in
         if expected == got
-          then Right ""
+          then Right ("" :: String)
           else Left (printf "Expected %s; got %s" (show expected) (show got) :: String)
     , testProperty "lines recognizes DOS line endings" $ over strSeries $ \str ->
-        sLines (SBS8.string $ unix2dos str) == sLines (SBS8.string str)
+        sLines (Q8.string $ unix2dos str) == sLines (Q8.string str)
     , testProperty "lines recognizes DOS line endings with tiny chunks" $ over strSeries $ \str ->
-        sLines (mapM_ SBS8.singleton $ unix2dos str) == sLines (mapM_ SBS8.singleton str)
+        sLines (mapM_ Q8.singleton $ unix2dos str) == sLines (mapM_ Q8.singleton str)
     , testProperty "lineSplit does not create null chunks (LF)" $ over ((,) <$> nats <~> strSeries) $ \(n,str) ->
-        noNullChunks (SBS8.lineSplit n (fromString str))
+        noNullChunks (Q8.lineSplit n (fromString str))
     , testProperty "lineSplit does not create null chunks (CRLF)" $ over ((,) <$> nats <~> strSeriesCrlf) $ \(n,str) ->
-        noNullChunks (SBS8.lineSplit n (fromString str))
+        noNullChunks (Q8.lineSplit n (fromString str))
     , testProperty "concat after lineSplit round trips (LF)" $ over ((,) <$> nats <~> strSeries) $ \(n,str) ->
-        unpackToString (SBS8.concat (SBS8.lineSplit n (fromString str))) == str
+        unpackToString (Q8.concat (Q8.lineSplit n (fromString str))) == str
     , testProperty "concat after lineSplit round trips (CRLF)" $ over ((,) <$> nats <~> strSeriesCrlf) $ \(n,str) ->
-        unpackToString (SBS8.concat (SBS8.lineSplit n (fromString str))) == str
+        unpackToString (Q8.concat (Q8.lineSplit n (fromString str))) == str
     ]
   , testGroup "Unit Tests"
     [ testCase "hGetContents: Handle stays open" handleIsOpen
     , testCase "group(By): Don't crash" groupCrash
+    , testCase "group: Char order" groupCharOrder
+    , testCase "groupBy: Char order" groupByCharOrder
     ]
   ]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
 
 module Main ( main ) where
 
@@ -79,23 +78,23 @@ groupCrash = do
 
 groupCharOrder :: Assertion
 groupCharOrder = do
-  a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.group $ Q8.fromLazy @IO "1234"
+  a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.group $ Q8.fromLazy "1234"
   a @?= (["1", "2", "3", "4"] :: [BL.ByteString])
-  b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.group $ Q8.fromLazy @IO "1122"
+  b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.group $ Q8.fromLazy "1122"
   b @?= (["11", "22"] :: [BL.ByteString])
 
 groupByCharOrder :: Assertion
 groupByCharOrder = do
   -- What about when everything fits into one group?
-  y <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\_ _ -> True) $ Q8.fromLazy @IO "abcd"
+  y <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\_ _ -> True) $ Q8.fromLazy "abcd"
   y @?= ["abcd"]
   -- Prove it's not an issue with the Char-based wrapper.
-  z <- S.toList_ . SM.mapsM Q.toLazy $ Q.groupBy (\a b -> a - 1 == b) $ Q.fromLazy @IO "98764321"
+  z <- S.toList_ . SM.mapsM Q.toLazy $ Q.groupBy (\a b -> a - 1 == b) $ Q.fromLazy "98764321"
   z @?= ["98", "76", "43", "21"]
   -- Char-based variant
-  a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\a b -> succ a == b) $ Q8.fromLazy @IO "12346789"
+  a <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (\a b -> succ a == b) $ Q8.fromLazy "12346789"
   a @?= ["12", "34", "67", "89"]
-  b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (on (==) (== '5')) $ Q8.fromLazy @IO "5678"
+  b <- S.toList_ . SM.mapsM Q8.toLazy $ Q8.groupBy (on (==) (== '5')) $ Q8.fromLazy "5678"
   b @?= ["5", "678"]
 
 goodFindIndex :: Assertion


### PR DESCRIPTION
While `groupBy` no longer crashes, it does seem to still have a strange `Char`
ordering bug that makes it effectively unusable. Looking at the nearly identical
code of `group`, it's likely that `group` also suffers from this, but the user
would never notice since `group` always uses `==` and thus element reordering
*within* a group would never matter.

This PR fixes this bug and adds tests to prove it.
