### PR TITLE
Documentation Overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - An order-of-magnitude performance improvement in line splitting, thanks to
   Viktor Dukhovni. [#18]
-- Docstring coverage is now 100%.
+- Documentation improved, and docstring coverage is now 100%. [#27]
 
 #### Fixed
 
@@ -17,6 +17,7 @@
 [#18]: https://github.com/haskell-streaming/streaming-bytestring/pull/18
 [#22]: https://github.com/haskell-streaming/streaming-bytestring/pull/22
 [#4]: https://github.com/haskell-streaming/streaming-bytestring/issues/4
+[#27]: https://github.com/haskell-streaming/streaming-bytestring/pull/27
 
 ## 0.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - An order-of-magnitude performance improvement in line splitting, thanks to
   Viktor Dukhovni. [#18]
+- Docstring coverage is now 100%.
 
 #### Fixed
 

--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -673,7 +673,7 @@ fold step0 begin finish p0 = loop p0 begin
 {-# INLINABLE fold #-}
 
 -- | 'fold_' keeps the return value of the left-folded bytestring. Useful for
--- simultaneous folds over a segmented bytestream
+-- simultaneous folds over a segmented bytestream.
 fold_ :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteString m r -> m (Of b r)
 fold_ step0 begin finish p0 = loop p0 begin
   where

--- a/Data/ByteString/Streaming.hs
+++ b/Data/ByteString/Streaming.hs
@@ -370,6 +370,12 @@ toLazy bs0 = dematerialize bs0
 -- >>> S.print $ mapped R.null $ Q.lines "yours,\nMeredith"
 -- False
 -- False
+--
+-- Suitable for use with `SP.mapped`:
+--
+-- @
+-- S.mapped Q.null :: Streaming (ByteString m) m r -> Stream (Of Bool) m r
+-- @
 null :: Monad m => ByteString m r -> m (Of Bool r)
 null (Empty r)  = return (True :> r)
 null (Go m)     = m >>= null
@@ -505,6 +511,11 @@ head_ (Go m)      = m >>= head_
 {-# INLINABLE head_ #-}
 
 -- | /O(c)/ Extract the first element of a 'ByteString', if there is one.
+-- Suitable for use with `SP.mapped`:
+--
+-- @
+-- S.mapped Q.head :: Stream (Q.ByteString m) m r -> Stream (Of (Maybe Word8)) m r
+-- @
 head :: Monad m => ByteString m r -> m (Of (Maybe Word8) r)
 head (Empty r)  = return (Nothing :> r)
 head (Chunk c rest) = case B.uncons c of
@@ -573,7 +584,12 @@ last_ (Chunk c0 cs0) = go c0 cs0
    go x (Go m)       = m >>= go x
 {-# INLINABLE last_ #-}
 
--- | Like `last_`, but suitable as an argument for `Streaming.mapped`.
+-- | Extract the last element of a `ByteString`, if possible. Suitable for use
+-- with `SP.mapped`:
+--
+-- @
+-- S.mapped Q.last :: Streaming (ByteString m) m r -> Stream (Of (Maybe Word8)) m r
+-- @
 last :: Monad m => ByteString m r -> m (Of (Maybe Word8) r)
 last (Empty r)      = return (Nothing :> r)
 last (Go m)         = m >>= last
@@ -1011,7 +1027,12 @@ count_ :: Monad m => Word8 -> ByteString m r -> m Int
 count_ w  = fmap (\(n :> _) -> n) . foldlChunks (\n c -> n + fromIntegral (B.count w c)) 0
 {-# INLINE count_ #-}
 
--- | Like `count_`, but suitable for use with `Streaming.mapped`.
+-- | Returns the number of times its argument appears in the `ByteString`.
+-- Suitable for use with `SP.mapped`:
+--
+-- @
+-- S.mapped (Q.count 37) :: Stream (Q.ByteString m) m r -> Stream (Of Int) m r
+-- @
 count :: Monad m => Word8 -> ByteString m r -> m (Of Int r)
 count w cs = foldlChunks (\n c -> n + fromIntegral (B.count w c)) 0 cs
 {-# INLINE count #-}

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -541,11 +541,11 @@ unlines = loop where
 {-# INLINABLE unlines #-}
 
 -- | 'words' breaks a byte stream up into a succession of byte streams
--- corresponding to words, breaking Chars representing white space. This is the
+-- corresponding to words, breaking on 'Char's representing white space. This is the
 -- genuinely streaming 'words'. A function that returns individual strict
 -- bytestrings would concatenate even infinitely long words like @cycle "y"@ in
--- memory. It is best for the user who has reflected on her materials to write
--- `mapped toStrict . words` or the like, if strict bytestrings are needed.
+-- memory. When the stream is known to not contain unreasonably long words, you can write
+`mapped toStrict . words` or the like, if strict bytestrings are needed.
 words :: Monad m => ByteString m r -> Stream (ByteString m) m r
 words =  filtered . R.splitWith B.isSpaceWord8
  where

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -43,7 +43,6 @@ module Data.ByteString.Streaming.Char8 (
     , drained
     , mwrap
 
-
     -- * Transforming ByteStrings
     , map              -- map :: Monad m => (Char -> Char) -> ByteString m r -> ByteString m r
     , intercalate      -- intercalate :: Monad m => ByteString m () -> Stream (ByteString m) m r -> ByteString m r
@@ -541,13 +540,14 @@ unlines = loop where
 {-# INLINABLE unlines #-}
 
 -- | 'words' breaks a byte stream up into a succession of byte streams
--- corresponding to words, breaking on 'Char's representing white space. This is the
--- genuinely streaming 'words'. A function that returns individual strict
+-- corresponding to words, breaking on 'Char's representing white space. This is
+-- the genuinely streaming 'words'. A function that returns individual strict
 -- bytestrings would concatenate even infinitely long words like @cycle "y"@ in
--- memory. When the stream is known to not contain unreasonably long words, you can write
-`mapped toStrict . words` or the like, if strict bytestrings are needed.
+-- memory. When the stream is known to not contain unreasonably long words, you
+-- can write @mapped toStrict . words@ or the like, if strict bytestrings are
+-- needed.
 words :: Monad m => ByteString m r -> Stream (ByteString m) m r
-words =  filtered . R.splitWith B.isSpaceWord8
+words = filtered . R.splitWith B.isSpaceWord8
  where
   filtered stream = case stream of
     Return r -> Return r

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -3,13 +3,20 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- | This library emulates "Data.ByteString.Lazy.Char8" but includes a monadic element
---   and thus at certain points uses a `Stream`/`FreeT` type in place of lists.
---   See the documentation for @Data.ByteString.Streaming@ and the examples of
---   of use to implement simple shell operations <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>. Examples of use
---   with @http-client@, @attoparsec@, @aeson@, @zlib@ etc. can be found in the
---   'streaming-utils' library.
-
+-- |
+-- Module      : Data.ByteString.Streaming.Char8
+-- Copyright   : (c) Don Stewart 2006
+--               (c) Duncan Coutts 2006-2011
+--               (c) Michael Thompson 2015
+-- License     : BSD-style
+--
+-- This library emulates "Data.ByteString.Lazy.Char8" but includes a monadic
+-- element and thus at certain points uses a `Stream`/@FreeT@ type in place of
+-- lists. See the documentation for @Data.ByteString.Streaming@ and the examples
+-- of of use to implement simple shell operations
+-- <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>. Examples of use
+-- with @http-client@, @attoparsec@, @aeson@, @zlib@ etc. can be found in the
+-- 'streaming-utils' library.
 
 module Data.ByteString.Streaming.Char8 (
     -- * The @ByteString@ type
@@ -383,8 +390,8 @@ repeat = R.repeat . c2w
 -- | 'cycle' ties a finite ByteString into a circular one, or equivalently,
 -- the infinite repetition of the original ByteString.
 --
--- | /O(n)/ The 'unfoldr' function is analogous to the Stream \'unfoldr\'.
--- 'unfoldr' builds a ByteString from a seed value. The function takes the
+-- | /O(n)/ The 'unfoldM' function is analogous to the Stream \'unfoldr\'.
+-- 'unfoldM' builds a ByteString from a seed value. The function takes the
 -- element and returns 'Nothing' if it is done producing the ByteString or
 -- returns 'Just' @(a,b)@, in which case, @a@ is a prepending to the ByteString
 -- and @b@ is used as the next element in a recursive call.
@@ -440,9 +447,9 @@ splitWith f = R.splitWith (f . w2c)
 > intercalate [c] . split c == id
 > split == splitWith . (==)
 
-As for all splitting functions in this library, this function does
-not copy the substrings, it just constructs new 'ByteStrings' that
-are slices of the original.
+As for all splitting functions in this library, this function does not copy the
+substrings, it just constructs new 'ByteString's that are slices of the
+original.
 
 >>> Q.stdout $ Q.unlines $ Q.split 'n' "banana peel"
 ba

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -402,7 +402,7 @@ unfoldM f = R.unfoldM go where
     Just (c,a') -> Just (c2w c, a')
 {-# INLINE unfoldM #-}
 
--- | Give some pure process that produces characters, generate a stream of bytes.
+-- | Given some pure process that produces characters, generate a stream of bytes.
 unfoldr :: (a -> Either r (Char, a)) -> a -> ByteString m r
 unfoldr step = R.unfoldr (either Left (\(c,a) -> Right (c2w c,a)) . step)
 {-# INLINE unfoldr #-}

--- a/Data/ByteString/Streaming/Char8.hs
+++ b/Data/ByteString/Streaming/Char8.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 -- |
 -- Module      : Data.ByteString.Streaming.Char8
 -- Copyright   : (c) Don Stewart 2006
@@ -180,7 +181,7 @@ import qualified Data.ByteString.Unsafe as B
 
 import           Streaming hiding (concats, distribute, unfold)
 import           Streaming.Internal (Stream(..))
-import qualified Streaming.Prelude as S
+import qualified Streaming.Prelude as SP
 
 import qualified Data.ByteString.Streaming as R
 import           Data.ByteString.Streaming.Internal
@@ -231,7 +232,7 @@ unpack bs = case bs of
 -- | /O(n)/ Convert a stream of separate characters into a packed byte stream.
 pack :: Monad m => Stream (Of Char) m r -> ByteString m r
 pack  = fromChunks
-        . mapped (fmap (\(str :> r) -> Char8.pack str :> r) . S.toList)
+        . mapped (fmap (\(str :> r) -> Char8.pack str :> r) . SP.toList)
         . chunksOf 32
 {-# INLINABLE pack #-}
 
@@ -273,7 +274,12 @@ head_ :: Monad m => ByteString m r -> m Char
 head_ = fmap w2c . R.head_
 {-# INLINE head_ #-}
 
--- | /O(1)/ Extract the first element of a ByteString, which may be non-empty
+-- | /O(1)/ Extract the first element of a ByteString, if possible. Suitable for
+-- use with `SP.mapped`:
+--
+-- @
+-- S.mapped Q.head :: Stream (Q.ByteString m) m r -> Stream (Of (Maybe Char)) m r
+-- @
 head :: Monad m => ByteString m r -> m (Of (Maybe Char) r)
 head = fmap (\(m:>r) -> fmap w2c m :> r) . R.head
 {-# INLINE head #-}
@@ -284,7 +290,12 @@ last_ :: Monad m => ByteString m r -> m Char
 last_ = fmap w2c . R.last_
 {-# INLINE last_ #-}
 
--- | Like `last_`, but suitable as an argument for `Streaming.mapped`.
+-- | Extract the last element of a `ByteString`, if possible. Suitable for use
+-- with `SP.mapped`:
+--
+-- @
+-- S.mapped Q.last :: Streaming (ByteString m) m r -> Stream (Of (Maybe Char)) m r
+-- @
 last :: Monad m => ByteString m r -> m (Of (Maybe Char) r)
 last = fmap (\(m:>r) -> fmap w2c m :> r) . R.last
 {-# INLINE last #-}
@@ -662,7 +673,12 @@ count_ :: Monad m => Char -> ByteString m r -> m Int
 count_ c = R.count_ (c2w c)
 {-# INLINE count_ #-}
 
--- | Like `count_`, but suitable for use with `Streaming.mapped`.
+-- | Returns the number of times its argument appears in the `ByteString`.
+-- Suitable for use with `SP.mapped`:
+--
+-- @
+-- S.mapped (Q.count 'a') :: Stream (Q.ByteString m) m r -> Stream (Of Int) m r
+-- @
 count :: Monad m => Char -> ByteString m r -> m (Of Int r)
 count c = R.count (c2w c)
 {-# INLINE count #-}

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -401,7 +401,7 @@ chunkMapM_ f bs = dematerialize bs return (\bs' mr -> f bs' >> mr) join
 
 -- | @chunkFold@ is preferable to @foldlChunks@ since it is an appropriate
 -- argument for @Control.Foldl.purely@ which permits many folds and sinks to be
--- run simulaneously on one bytestream.
+-- run simultaneously on one bytestream.
 chunkFold :: Monad m => (x -> B.ByteString -> x) -> x -> (x -> a) -> ByteString m r -> m (Of a r)
 chunkFold step begin done = go begin
   where go a _            | a `seq` False = undefined
@@ -410,9 +410,9 @@ chunkFold step begin done = go begin
         go a (Go m)       = m >>= go a
 {-# INLINABLE chunkFold #-}
 
--- | @chunkFoldM@ is preferable to @foldlChunksM@ since it is an appropriate
--- argument for @Control.Foldl.impurely@ which permits many folds and sinks to
--- be run simulaneously on one bytestream.
+-- | 'chunkFoldM' is preferable to 'foldlChunksM' since it is an appropriate
+-- argument for 'Control.Foldl.impurely' which permits many folds and sinks to
+-- be run simultaneously on one bytestream.
 chunkFoldM :: Monad m => (x -> B.ByteString -> m x) -> m x -> (x -> m a) -> ByteString m r -> m (Of a r)
 chunkFoldM step begin done bs = begin >>= go bs
   where
@@ -452,7 +452,7 @@ unfoldrNE i f x0
 {-# INLINE unfoldrNE #-}
 
 -- | Given some continual monadic action that produces strict `B.ByteString`
--- chuncks, produce a stream of bytes.
+-- chunks, produce a stream of bytes.
 unfoldMChunks :: Monad m => (s -> m (Maybe (B.ByteString, s))) -> s -> ByteString m ()
 unfoldMChunks step = loop where
   loop s = Go $ do
@@ -473,7 +473,7 @@ unfoldrChunks step = loop where
 {-# INLINABLE unfoldrChunks #-}
 
 -- | Stream chunks from something that contains @IO (Maybe ByteString)@ until it
--- returns @Nothing@. @reread@ is of particular use rendering @io-streams@ input
+-- returns 'Nothing'. 'reread' is of particular use rendering @io-streams@ input
 -- streams as byte streams in the present sense.
 --
 -- > Q.reread Streams.read            :: InputStream B.ByteString -> Q.ByteString IO ()

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -9,6 +9,13 @@
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE UnliftedFFITypes      #-}
 
+-- |
+-- Module      : Data.ByteString.Streaming.Internal
+-- Copyright   : (c) Don Stewart 2006
+--               (c) Duncan Coutts 2006-2011
+--               (c) Michael Thompson 2015
+-- License     : BSD-style
+
 module Data.ByteString.Streaming.Internal (
    ByteString (..)
    , consChunk             -- :: S.ByteString -> ByteString m r -> ByteString m r
@@ -190,7 +197,7 @@ instance (MonadResource m) => MonadResource (ByteString m) where
   liftResourceT = lift . liftResourceT
   {-# INLINE liftResourceT #-}
 
--- | Like `bracket`, but specialized for `ByteString`.
+-- | Like @bracket@, but specialized for `ByteString`.
 bracketByteString :: MonadResource m => IO a -> (a -> IO ()) -> (a -> ByteString m b) -> ByteString m b
 bracketByteString alloc free inside = do
         (key, seed) <- lift (allocate alloc free)
@@ -430,7 +437,7 @@ foldrChunksM :: Monad m => (B.ByteString -> m a -> m a) -> m a -> ByteString m r
 foldrChunksM step nil bs = dematerialize bs (const nil) step join
 {-# INLINE foldrChunksM #-}
 
--- | Internal utility for `unfoldr`.
+-- | Internal utility for @unfoldr@.
 unfoldrNE :: Int -> (a -> Either r (Word8, a)) -> a -> (B.ByteString, Either r a)
 unfoldrNE i f x0
     | i < 0     = (B.empty, Right x0)

--- a/Data/ByteString/Streaming/Internal.hs
+++ b/Data/ByteString/Streaming/Internal.hs
@@ -324,6 +324,8 @@ packBytes cs0 = do
 {-# INLINABLE packBytes #-}
 
 -- | Convert a vanilla `Stream` of characters into a stream of bytes.
+--
+-- /Note:/ Each `Char` value is truncated to 8 bits.
 packChars :: Monad m => Stream (Of Char) m r -> ByteString m r
 packChars = packBytes . SP.map B.c2w
 {-# INLINABLE packChars #-}

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -1,156 +1,17 @@
 cabal-version:      >=1.10
 name:               streaming-bytestring
 version:            0.1.6
-synopsis:           effectful byte steams, or: bytestring io done right.
+synopsis:           Fast, effectful byte steams.
 description:
-  This is an implementation of effectful, memory-constrained bytestrings (byte
-  streams) and functions for streaming bytestring manipulation, adequate for
-  non-lazy-io. Some examples of the use of byte streams to implement simple
-  shell progams can be found
-  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>. See also the
-  illustrations of use with e.g. @attoparsec@, @aeson@, @http-client@, @zlib@
-  etc. in the <https://hackage.haskell.org/package/streaming-utils streaming-utils>
-  library. Usage is as close as possible to that of @ByteString@ and lazy @ByteString@.
+  This library enables fast and safe streaming of byte data, in either @Word8@ or
+  @Char@ form. It is a core addition to the <https://github.com/haskell-streaming streaming ecosystem>
+  and avoids the usual pitfalls of combinbing lazy @ByteString@s with lazy @IO@.
   .
-  A @ByteString IO ()@ is the most natural representation of an effectful stream
-  of bytes arising chunkwise from a handle. Indeed, the implementation follows
-  the details of @Data.ByteString.Lazy@ and @Data.ByteString.Lazy.Char8@ in
-  unrelenting detail, omitting only transparently non-streaming operations like
-  @reverse@. It is just a question of replacing the lazy bytestring type:
+  We follow the philosophy shared by @streaming@ that "the best API is the one
+  you already know". Thus this library mirrors the API of the @bytestring@
+  library as closely as possible.
   .
-  > data ByteString     = Empty   | Chunk Strict.ByteString ByteString
-  .
-  with the /minimal/ effectful variant:
-  .
-  > data ByteString m r = Empty r | Chunk Strict.ByteString (ByteString m r) | Go (m (ByteString m r))
-  .
-  (Constructors are necessarily hidden in internal modules in both the @Lazy@ and the @Streaming@.)
-  .
-  That's it. As a lazy bytestring is implemented internally by a sort of list of
-  strict bytestring chunks, a streaming bytestring is simply implemented as a
-  /producer/ or /generator/ of strict bytestring chunks. Most operations are
-  defined by simply adding a line to what we find in @Data.ByteString.Lazy@. The
-  only possible simplification would involve specializing to @IO@, throughout -
-  but this would e.g. block the use of @ResourceT@ to manage handles and the
-  like, and a number of other convenient operations like @copy@, which permits
-  one to apply two operations simultaneously over the length of the byte stream.
-  .
-  Something like this alteration of type is of course obvious and mechanical,
-  once the idea of an effectful bytestring type is contemplated and lazy io is
-  rejected. Indeed it seems that this is the proper expression of what was
-  intended by lazy bytestrings to begin with. The documentation, after all,
-  reads
-  .
-  * \"A key feature of lazy ByteStrings is the means to manipulate large or
-  unbounded streams of data without requiring the entire sequence to be resident
-  in memory. To take advantage of this you have to write your functions in a
-  lazy streaming style, e.g. classic pipeline composition. The default I/O chunk
-  size is 32k, which should be good in most circumstances.\"
-  .
-  ... which is very much the idea of this library: the default chunk size for
-  'hGetContents' and the like follows @Data.ByteString.Lazy@; operations like
-  @lines@ and @append@ and so on are tailored not to increase chunk size.
-  .
-  The present library is thus if you like nothing but /lazy bytestring done
-  right/. The authors of @Data.ByteString.Lazy@ must have supposed that the
-  directly monadic formulation of such their type would necessarily make things
-  slower. This appears to be a prejudice. For example, passing a large file of
-  short lines through this benchmark transformation
-  .
-  > Lazy.unlines      . map    (\bs -> "!"       <> Lazy.drop 5 bs)       . Lazy.lines
-  > Streaming.unlines . S.maps (\bs -> chunk "!" >> Streaming.drop 5 bs)  . Streaming.lines
-  .
-  gives pleasing results like these
-  .
-  > $  time ./benchlines lazy >> /dev/null
-  > real	0m2.097s
-  > ...
-  > $  time ./benchlines streaming >> /dev/null
-  > real	0m1.930s
-  .
-  For a more sophisticated operation like
-  .
-  > Lazy.intercalate "!\n"      . Lazy.lines
-  > Streaming.intercalate "!\n" . Streaming.lines
-  .
-  we get results like these:
-  .
-  > time ./benchlines lazy >> /dev/null
-  > real	0m1.250s
-  > ...
-  > time ./benchlines streaming >> /dev/null
-  > real	0m1.531s
-  .
-  The pipes environment would express the latter as
-  .
-  > Pipes.intercalates (Pipes.yield "!\n") . view Pipes.lines
-  .
-  meaning almost exactly what we mean above, but with results like this
-  .
-  >  time ./benchlines pipes >> /dev/null
-  >  real	0m6.353s
-  .
-  The difference, however, /is emphatically not intrinsic to pipes/; it is just
-  that this library depends the @streaming@ library, which is used in place of
-  @free@ to express the
-  <http://www.haskellforall.com/2013/09/perfect-streaming-using-pipes-bytestring.html "perfectly streaming">
-  splitting and iterated division or "chunking" of byte streams.
-  .
-  These concepts belong to the ABCs of streaming; @lines@ is just a textbook
-  example, and it is of course handled correctly in @Data.ByteString.Lazy@. But
-  the concepts are /catastrophically mishandled/ in /all/ streaming io libraries
-  other than pipes. Already the @enumerator@ and @iteratee@ libraries were
-  completely defeated by @lines@: see e.g. the @enumerator@ implementation of
-  <http://hackage.haskell.org/package/enumerator-0.4.20/docs/Data-Enumerator-Text.html#v:splitWhen splitWhen and lines>.
-  .
-  This will concatenate strict text forever, if that's what is coming in. The
-  rot spreads from there. It is just a fact that in all of the general streaming
-  io frameworks other than pipes,it becomes torture to express elementary
-  distinctions that are transparently and immediately contained in any idea of
-  streaming whatsoever.
-  .
-  Though, as was said above, we barely alter signatures in
-  @Data.ByteString.Lazy@ more than is required by the types, the point of view
-  that emerges is very much that of @pipes-bytestring@ and @pipes-group@. In
-  particular we have these correspondences:
-  .
-  > Lazy.splitAt      :: Int -> ByteString              -> (ByteString, ByteString)
-  > Streaming.splitAt :: Int -> ByteString m r          -> ByteString m (ByteString m r)
-  > Pipes.splitAt     :: Int -> Producer ByteString m r -> Producer ByteString m (Producer ByteString m r)
-  .
-  and
-  .
-  > Lazy.lines      :: ByteString -> [ByteString]
-  > Streaming.lines :: ByteString m r -> Stream (ByteString m) m r
-  > Pipes.lines     :: Producer ByteString m r -> FreeT (Producer ByteString m) m r
-  .
-  where the @Stream@ type expresses the sequencing of @ByteString m _@ layers
-  with the usual \'free monad\' sequencing.
-  .
-  Interoperation with @pipes-bytestring@ uses this isomorphism:
-  .
-  > Streaming.ByteString.unfoldrChunks Pipes.next :: Monad m => Producer ByteString m r -> ByteString m r
-  > Pipes.unfoldr Streaming.ByteString.nextChunk  :: Monad m => ByteString m r -> Producer ByteString m r
-  .
-  Interoperation with @io-streams@ is thus:
-  .
-  > IOStreams.unfoldM Streaming.ByteString.unconsChunk :: ByteString IO () -> IO (InputStream ByteString)
-  > Streaming.ByteString.reread IOStreams.read         :: InputStream ByteString -> ByteString IO ()
-  .
-  and similarly for other rational streaming io libraries.
-  .
-  Problems and questions about the library can be put as issues on the github
-  page, or mailed to the <https://groups.google.com/forum/#!forum/haskell-pipes pipes list>.
-  .
-  A tutorial module is in the works;
-  <https://gist.github.com/michaelt/6c6843e6dd8030e95d58 here>, for the moment,
-  is a sequence of simplified implementations of familiar shell utilities. The
-  same programs are implemented at the end of the excellent
-  <http://hackage.haskell.org/package/io-streams-1.3.2.0/docs/System-IO-Streams-Tutorial.html io-streams tutorial>.
-  It is generally much simpler; in some case simpler than what you would write
-  with lazy bytestrings. <https://gist.github.com/michaelt/2dcea1ba32562c091357 Here>
-  is a simple GET request that returns a byte stream.
-  .
+  See the module documentation and the README for more information.
 
 license:            BSD3
 license-file:       LICENSE

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -102,6 +102,18 @@ goodFindIndex = do
   assertBool "Expected the length of the string" $ QI.findIndexOrEnd (const False) "1234" == 4
   assertBool "Expected 0" $ QI.findIndexOrEnd (const True) "1234" == 0
 
+firstI :: Assertion
+firstI = do
+  l <- runResourceT
+    . S.length_                        -- IO Int
+    . S.filter (== 'i')
+    . S.concat                         -- Stream (Of Char) IO ()
+    . S.mapped Q8.head                 -- Stream (Of (Maybe Char)) IO ()
+    . Q8.denull                        -- Stream (ByteString IO) IO ()
+    . Q8.lines                         -- Stream (Bytestring IO) IO ()
+    $ Q8.readFile "tests/groupBy.txt"  -- ByteString IO ()
+  l @?= 57
+
 main :: IO ()
 main = defaultMain $ testGroup "Tests"
   [ testGroup "Property Tests"
@@ -135,5 +147,6 @@ main = defaultMain $ testGroup "Tests"
     , testCase "group: Char order" groupCharOrder
     , testCase "groupBy: Char order" groupByCharOrder
     , testCase "findIndexOrEnd" goodFindIndex
+    , testCase "Stream Interop" firstI
     ]
   ]


### PR DESCRIPTION
The `streaming` ecosystem is wonderful, but its public-facing documentation contains much content from its early days of experimentation. These explanations tend to be verbose and lack practical examples.

This PR reworks this library's README and other relevant documentation to be more user friendly.

Docstring coverage is now also 100%.
