### PR TITLE
Some miscellaneous fixes for next release (Word8 module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,59 @@
 ## Unreleased
 
-#### Fixed
+## 0.2.0 (TBD)
+
+#### Breaking changes [#42]
+
+- Switch names of `fold` and `fold_` in the non-`Char8` modules.  The
+  corresponding `Char8` functions and the rest of the library uses `_`
+  for the variant that forgets the `r` value.
+
+#### Fixed [#42]
+
+- Fix intersperse implementation to ignore any initial empty chunks.
+- Fix intercalate implementation to not insert anything between the
+  final substream and the outer stream end.
+- Fix bug in `unlines`, it incorrectly differentiates between `Chunk ""
+  (Empty r)` and `Empty r`.  There's no such difference.  Also this
+  dubious distinction was not made when the two forms are behind a
+  monadic effect.
+- Import 'SPEC' from GHC.Types, as of 9.0, GHC.Exts no longer exports
+  `SpecConstrAnnotation`.
+
+#### Fixed [#43]
 
 - An edge case involving overflow in `readInt`. [#43]
 
+[#42]: https://github.com/haskell-streaming/streaming-bytestring/pull/42
 [#43]: https://github.com/haskell-streaming/streaming-bytestring/pull/43
+
+#### Added [#42]
+
+- Add missing `zipWithStream` export in `Char8` module
+- Add missing `materialize` and `dematerialize` exports in "Word8"
+  module
+- Relax signature of `toStrict_` to allow any `r`, not just `()`.
+
+#### Performance [#42]
+
+- Make packChars more efficient by leaving c2w conversion to the
+  ByteString library (should be free, or at least much cheaper in
+  `poke p (c2w c)`, since we avoid converting the input stream).
+- More performant rewrite of `denull`.  Less abstract machinery.
+- Delegate c2w in packChars to Data.ByteString.Char8.packChars,
+  this avoids costlier transformations of the stream.
+
+#### Documentation [#42]
+
+- In `foldr` docs remove erroneous claim that `foldr cons = id`
+- Small improvements in function grouping of documentation and typo fix
+- Drop signature comments from the export lists, they were not
+  consistently there, and were sometimes wrong.  Too much effort to
+  maintain for too little benefit.
+- Fix some typos
+- Make origin of 'io-streams` `Streams` module, `InputStream` type, more
+  explicit.
+- Use <BLANKLINE> in haddock for literal blanks in the output.
 
 ## 0.1.7 (2020-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 - Switch names of `fold` and `fold_` in the non-`Char8` modules.  The
   corresponding `Char8` functions and the rest of the library uses `_`
   for the variant that forgets the `r` value.
+- Unify `Streaming.ByteString.nextByte` and `uncons`.  The old `uncons`
+  returned `Maybe` instead of the more natural `Either r`.  It also did not
+  handle empty chunks correctly.  A deprecated alias `nextByte = uncons`
+  is retained to facilitate migration to the new improved `uncons`.
+- Unify `Streaming.ByteString.Char8.nextChar` and `uncons`.  The old `uncons`
+  did not handle empty chunks correctly.  A deprecated alias of `nextChar`
+  is retained to facilitate migration to the new improved `uncons`.
+- Unify `unconsChunk` and `nextChunk`.  The old `unconsChunk` returned
+  `Maybe` instead of the more natural `Either r`.  A deprecated alias is
+  retained to facilitate migration to the new improved `unconsChunk`.
 
 #### Fixed [#42]
 

--- a/lib/Streaming/ByteString.hs
+++ b/lib/Streaming/ByteString.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP          #-}
 {-# LANGUAGE GADTs        #-}
+{-# LANGUAGE LambdaCase   #-}
 {-# LANGUAGE RankNTypes   #-}
 
 -- |
@@ -51,79 +52,80 @@ module Streaming.ByteString
   , ByteString
 
     -- * Introducing and eliminating 'ByteStream's
-  , empty            -- empty :: ByteStream m ()
-  , singleton        -- singleton :: Monad m => Word8 -> ByteStream m ()
-  , pack             -- pack :: Monad m => Stream (Of Word8) m r -> ByteStream m r
-  , unpack           -- unpack :: Monad m => ByteStream m r -> Stream (Of Word8) m r
-  , fromLazy         -- fromLazy :: Monad m => ByteString -> ByteStream m ()
-  , toLazy           -- toLazy :: Monad m => ByteStream m () -> m ByteString
-  , toLazy_          -- toLazy' :: Monad m => ByteStream m () -> m (Of ByteString r)
-  , fromChunks       -- fromChunks :: Monad m => Stream (Of ByteString) m r -> ByteStream m r
-  , toChunks         -- toChunks :: Monad m => ByteStream m r -> Stream (Of ByteString) m r
-  , fromStrict       -- fromStrict :: ByteString -> ByteStream m ()
-  , toStrict         -- toStrict :: Monad m => ByteStream m () -> m ByteString
-  , toStrict_        -- toStrict_ :: Monad m => ByteStream m r -> m (Of ByteString r)
+  , empty
+  , singleton
+  , pack
+  , unpack
+  , fromLazy
+  , toLazy
+  , toLazy_
+  , fromChunks
+  , toChunks
+  , fromStrict
+  , toStrict
+  , toStrict_
   , effects
   , copy
   , drained
   , mwrap
-  , distribute       -- distribute :: ByteStream (t m) a -> t (ByteStream m) a
 
     -- * Transforming ByteStreams
-  , map              -- map :: Monad m => (Word8 -> Word8) -> ByteStream m r -> ByteStream m r
-  , intercalate      -- intercalate :: Monad m => ByteStream m () -> Stream (ByteStream m) m r -> ByteStream m r
-  , intersperse      -- intersperse :: Monad m => Word8 -> ByteStream m r -> ByteStream m r
+  , map
+  , intercalate
+  , intersperse
 
     -- * Basic interface
-  , cons             -- cons :: Monad m => Word8 -> ByteStream m r -> ByteStream m r
-  , cons'            -- cons' :: Word8 -> ByteStream m r -> ByteStream m r
+  , cons
+  , cons'
   , snoc
-  , append           -- append :: Monad m => ByteStream m r -> ByteStream m s -> ByteStream m s
-  , filter           -- filter :: (Word8 -> Bool) -> ByteStream m r -> ByteStream m r
-  , uncons           -- uncons :: Monad m => ByteStream m r -> m (Either r (Word8, ByteStream m r))
-  , nextByte -- nextByte :: Monad m => ByteStream m r -> m (Either r (Word8, ByteStream m r))
-  , denull
+  , append
+  , filter
+  , uncons
+  , nextByte
 
     -- * Substrings
     -- ** Breaking strings
-  , break            -- break :: Monad m => (Word8 -> Bool) -> ByteStream m r -> ByteStream m (ByteStream m r)
-  , drop             -- drop :: Monad m => GHC.Int.Int64 -> ByteStream m r -> ByteStream m r
+  , break
+  , drop
   , dropWhile
-  , group            -- group :: Monad m => ByteStream m r -> Stream (ByteStream m) m r
+  , group
   , groupBy
-  , span             -- span :: Monad m => (Word8 -> Bool) -> ByteStream m r -> ByteStream m (ByteStream m r)
-  , splitAt          -- splitAt :: Monad m => GHC.Int.Int64 -> ByteStream m r -> ByteStream m (ByteStream m r)
-  , splitWith        -- splitWith :: Monad m => (Word8 -> Bool) -> ByteStream m r -> Stream (ByteStream m) m r
-  , take             -- take :: Monad m => GHC.Int.Int64 -> ByteStream m r -> ByteStream m ()
-  , takeWhile        -- takeWhile :: (Word8 -> Bool) -> ByteStream m r -> ByteStream m ()
+  , span
+  , splitAt
+  , splitWith
+  , take
+  , takeWhile
 
     -- ** Breaking into many substrings
-  , split            -- split :: Monad m => Word8 -> ByteStream m r -> Stream (ByteStream m) m r
+  , split
 
     -- ** Special folds
-  , concat          -- concat :: Monad m => Stream (ByteStream m) m r -> ByteStream m r
+  , concat
+  , denull
 
     -- * Builders
-  , toStreamingByteStringWith
   , toStreamingByteString
+
+  , toStreamingByteStringWith
+
   , toBuilder
   , concatBuilders
 
     -- * Building ByteStreams
     -- ** Infinite ByteStreams
-  , repeat           -- repeat :: Word8 -> ByteStream m r
-  , iterate          -- iterate :: (Word8 -> Word8) -> Word8 -> ByteStream m r
-  , cycle            -- cycle :: Monad m => ByteStream m r -> ByteStream m s
+  , repeat
+  , iterate
+  , cycle
 
     -- ** Unfolding ByteStreams
-  , unfoldM          -- unfoldr :: (a -> m (Maybe (Word8, a))) -> m a -> ByteStream m ()
-  , unfoldr          -- unfold  :: (a -> Either r (Word8, a)) -> a -> ByteStream m r
+  , unfoldM
+  , unfoldr
   , reread
 
     -- *  Folds, including support for `Control.Foldl`
-  , foldr            -- foldr :: Monad m => (Word8 -> a -> a) -> a -> ByteStream m () -> m a
-  , fold             -- fold :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteStream m () -> m b
-  , fold_            -- fold' :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteStream m r -> m (b, r)
+  , foldr
+  , fold
+  , fold_
   , head
   , head_
   , last
@@ -139,29 +141,27 @@ module Streaming.ByteString
 
     -- * I\/O with 'ByteStream's
     -- ** Standard input and output
-  , getContents      -- getContents :: ByteStream IO ()
-  , stdin            -- stdin :: ByteStream IO ()
-  , stdout           -- stdout :: ByteStream IO r -> IO r
-  , interact         -- interact :: (ByteStream IO () -> ByteStream IO r) -> IO r
+  , getContents
+  , stdin
+  , stdout
+  , interact
 
     -- ** Files
-  , readFile         -- readFile :: FilePath -> ByteStream IO ()
-  , writeFile        -- writeFile :: FilePath -> ByteStream IO r -> IO r
-  , appendFile       -- appendFile :: FilePath -> ByteStream IO r -> IO r
+  , readFile
+  , writeFile
+  , appendFile
 
     -- ** I\/O with Handles
-  , fromHandle       -- fromHandle :: Handle -> ByteStream IO ()
-  , toHandle         -- toHandle :: Handle -> ByteStream IO r -> IO r
-  , hGet             -- hGet :: Handle -> Int -> ByteStream IO ()
-  , hGetContents     -- hGetContents :: Handle -> ByteStream IO ()
-  , hGetContentsN    -- hGetContentsN :: Int -> Handle -> ByteStream IO ()
-  , hGetN            -- hGetN :: Int -> Handle -> Int -> ByteStream IO ()
-  , hGetNonBlocking  -- hGetNonBlocking :: Handle -> Int -> ByteStream IO ()
-  , hGetNonBlockingN -- hGetNonBlockingN :: Int -> Handle -> Int -> ByteStream IO ()
-  , hPut             -- hPut :: Handle -> ByteStream IO r -> IO r
-  --    , hPutNonBlocking  -- hPutNonBlocking :: Handle -> ByteStream IO r -> ByteStream IO r
-    -- * Etc.
-  , zipWithStream    -- zipWithStream :: Monad m => (forall x. a -> ByteStream m x -> ByteStream m x) -> [a] -> Stream (ByteStream m) m r -> Stream (ByteStream m) m r
+  , fromHandle
+  , toHandle
+  , hGet
+  , hGetContents
+  , hGetContentsN
+  , hGetN
+  , hGetNonBlocking
+  , hGetNonBlockingN
+  , hPut
+  --    , hPutNonBlocking
 
     -- * Simple chunkwise operations
   , unconsChunk
@@ -174,6 +174,12 @@ module Streaming.ByteString
   , chunkMap
   , chunkMapM
   , chunkMapM_
+
+    -- * Etc.
+  , dematerialize
+  , materialize
+  , distribute
+  , zipWithStream
   ) where
 
 import           Prelude hiding
@@ -286,8 +292,12 @@ fromStrict bs | B.null bs = Empty ()
 -- Note that this is an /expensive/ operation that forces the whole monadic
 -- ByteString into memory and then copies all the data. If possible, try to
 -- avoid converting back and forth between streaming and strict bytestrings.
-toStrict_ :: Monad m => ByteStream m () -> m B.ByteString
+toStrict_ :: Monad m => ByteStream m r -> m B.ByteString
+#if MIN_VERSION_streaming (0,2,2)
 toStrict_ = fmap B.concat . SP.toList_ . toChunks
+#else
+toStrict_ = fmap B.concat . SP.toList_ . void . toChunks
+#endif
 {-# INLINE toStrict_ #-}
 
 -- | /O(n)/ Convert a monadic byte stream into a single strict 'ByteString',
@@ -410,15 +420,44 @@ testNull p@(Chunk bs rest) = if B.null bs
 
 -- | Remove empty ByteStrings from a stream of bytestrings.
 denull :: Monad m => Stream (ByteStream m) m r -> Stream (ByteStream m) m r
-denull = hoist (run . maps effects) . separate . mapped nulls
-{-# INLINE denull #-}
+{-# INLINABLE denull #-}
+denull = loop . Right
+  where
+    -- Scan each substream, dropping empty chunks along the way.  As soon as a
+    -- non-empty chunk is found, just apply the loop to the next substream in
+    -- the terminal value via fmap.  If Empty comes up before that happens,
+    -- continue the current stream instead with its denulled tail.
+    --
+    -- This implementation is tail recursive:
+    -- * Recursion via 'loop . Left' continues scanning an inner ByteStream.
+    -- * Recursion via 'loop . Right' moves to the next substream.
+    --
+    -- The old version below was shorter, but noticeably slower, especially
+    -- when empty substreams are frequent:
+    --
+    --    denull = hoist (run . maps effects) . separate . mapped nulls
+    --
+    loop = \ case
+      Left mbs -> case mbs of
+          Chunk c cs | B.length c > 0 -> Step $ Chunk c $ fmap (loop . Right) cs
+                     | otherwise      -> loop $ Left cs
+          Go m                        -> Effect $ loop . Left <$> m
+          Empty r                     -> loop $ Right r
+      Right strm -> case strm of
+        Step mbs -> case mbs of
+          Chunk c cs | B.length c > 0 -> Step $ Chunk c $ fmap (loop . Right) cs
+                     | otherwise      -> loop $ Left cs
+          Go m                        -> Effect $ loop . Left <$> m
+          Empty r                     -> loop $ Right r
+        Effect m                      -> Effect $ fmap (loop . Right) m
+        r@(Return _)                  -> r
 
 {-| /O1/ Distinguish empty from non-empty lines, while maintaining streaming;
     the empty ByteStrings are on the right
 
 >>> nulls  ::  ByteStream m r -> m (Sum (ByteStream m) (ByteStream m) r)
 
-    There are many ways to remove null bytestrings from a
+    There are many (generally slower) ways to remove null bytestrings from a
     @Stream (ByteStream m) m r@ (besides using @denull@). If we pass next to
 
 >>> mapped nulls bs :: Stream (Sum (ByteStream m) (ByteStream m)) m r
@@ -622,49 +661,49 @@ map f z = dematerialize z Empty (Chunk . B.map f) Go
 intersperse :: Monad m => Word8 -> ByteStream m r -> ByteStream m r
 intersperse _ (Empty r)    = Empty r
 intersperse w (Go m)       = Go (fmap (intersperse w) m)
-intersperse w (Chunk c cs) = Chunk (B.intersperse w c)
-                                   (dematerialize cs Empty (Chunk . intersperse') Go)
+intersperse w (Chunk c cs) | B.null c = intersperse w cs
+                           | otherwise =
+                               Chunk (B.intersperse w c)
+                                 (dematerialize cs Empty (Chunk . intersperse') Go)
   where intersperse' :: P.ByteString -> P.ByteString
-        intersperse' (B.PS fp o l) =
-          B.unsafeCreate (2*l) $ \p' -> withForeignPtr fp $ \p -> do
-            poke p' w
-            B.c_intersperse (p' `plusPtr` 1) (p `plusPtr` o) (fromIntegral l) w
-
+        intersperse' (B.PS fp o l)
+          | l > 0 = B.unsafeCreate (2*l) $ \p' -> withForeignPtr fp $ \p -> do
+              poke p' w
+              B.c_intersperse (p' `plusPtr` 1) (p `plusPtr` o) (fromIntegral l) w
+          | otherwise = B.empty
 {-# INLINABLE intersperse #-}
 
 -- | 'foldr', applied to a binary operator, a starting value (typically the
 -- right-identity of the operator), and a ByteStream, reduces the ByteStream
 -- using the binary operator, from right to left.
 --
--- > foldr cons = id
---
 foldr :: Monad m => (Word8 -> a -> a) -> a -> ByteStream m () -> m a
 foldr k = foldrChunks (flip (B.foldr k))
 {-# INLINE foldr #-}
 
--- | 'fold', applied to a binary operator, a starting value (typically the
+-- | 'fold_', applied to a binary operator, a starting value (typically the
 -- left-identity of the operator), and a ByteStream, reduces the ByteStream
 -- using the binary operator, from left to right. We use the style of the foldl
--- libarary for left folds
-fold :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteStream m () -> m b
-fold step0 begin finish p0 = loop p0 begin
-  where
-    loop p !x = case p of
-        Chunk bs bss -> loop bss $! B.foldl' step0 x bs
-        Go    m      -> m >>= \p' -> loop p' x
-        Empty _      -> return (finish x)
-{-# INLINABLE fold #-}
-
--- | 'fold_' keeps the return value of the left-folded bytestring. Useful for
--- simultaneous folds over a segmented bytestream.
-fold_ :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteStream m r -> m (Of b r)
+-- library for left folds
+fold_ :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteStream m () -> m b
 fold_ step0 begin finish p0 = loop p0 begin
   where
     loop p !x = case p of
         Chunk bs bss -> loop bss $! B.foldl' step0 x bs
         Go    m      -> m >>= \p' -> loop p' x
-        Empty r      -> return (finish x :> r)
+        Empty _      -> return (finish x)
 {-# INLINABLE fold_ #-}
+
+-- | 'fold' keeps the return value of the left-folded bytestring. Useful for
+-- simultaneous folds over a segmented bytestream.
+fold :: Monad m => (x -> Word8 -> x) -> x -> (x -> b) -> ByteStream m r -> m (Of b r)
+fold step0 begin finish p0 = loop p0 begin
+  where
+    loop p !x = case p of
+        Chunk bs bss -> loop bss $! B.foldl' step0 x bs
+        Go    m      -> m >>= \p' -> loop p' x
+        Empty r      -> return (finish x :> r)
+{-# INLINABLE fold #-}
 
 -- ---------------------------------------------------------------------
 -- Special folds
@@ -786,10 +825,9 @@ take i cs0         = take' i cs0
 >>> Q.putStrLn $ Q.drop 6 "Wisconsin"
 sin
 >>> Q.putStrLn $ Q.drop 16 "Wisconsin"
-
->>>
+<BLANKLINE>
 -}
-drop  :: Monad m => Int64 -> ByteStream m r -> ByteStream m r
+drop :: Monad m => Int64 -> ByteStream m r -> ByteStream m r
 drop i p | i <= 0 = p
 drop i cs0 = drop' i cs0
   where drop' 0 cs           = cs
@@ -975,20 +1013,13 @@ groupBy rel = go
 -- 'ByteStream's and concatenates the list after interspersing the first
 -- argument between each element of the list.
 intercalate :: Monad m => ByteStream m () -> Stream (ByteStream m) m r -> ByteStream m r
-intercalate _ (Return r) = Empty r
-intercalate s (Effect m) = Go $ fmap (intercalate s) m
-intercalate s (Step bs0) = do  -- this isn't quite right
-  ls <- bs0
-  s
-  intercalate s ls
- -- where
- --  loop (Return r) =  Empty r -- concat . (L.intersperse s)
- --  loop (Effect m) = Go $ fmap loop m
- --  loop (Step bs) = do
- --    ls <- bs
- --    case ls of
- --      Return r -> Empty r  -- no '\n' before end, in this case.
- --      x -> s >> loop x
+intercalate s = loop
+  where
+    loop (Return r) = Empty r
+    loop (Effect m) = Go $ fmap loop m
+    loop (Step bs) = bs >>= \case
+        Return r -> Empty r  -- not between final substream and stream end
+        x        -> s >> loop x
 {-# INLINABLE intercalate #-}
 
 -- | Returns the number of times its argument appears in the `ByteStream`.
@@ -1250,8 +1281,8 @@ revChunks cs r = L.foldl' (flip Chunk) (Empty r) cs
 
 -- | Zip a list and a stream-of-byte-streams together.
 zipWithStream
-  :: (Monad m)
-  =>  (forall x . a -> ByteStream m x -> ByteStream m x)
+  :: Monad m
+  => (forall x . a -> ByteStream m x -> ByteStream m x)
   -> [a]
   -> Stream (ByteStream m) m r
   -> Stream (ByteStream m) m r

--- a/lib/Streaming/ByteString/Char8.hs
+++ b/lib/Streaming/ByteString/Char8.hs
@@ -26,20 +26,20 @@ module Streaming.ByteString.Char8
   , ByteString
 
     -- * Introducing and eliminating 'ByteStream's
-  , empty            -- empty :: ByteStream m ()
-  , pack             -- pack :: Monad m => String -> ByteStream m ()
+  , empty
+  , pack
   , unpack
   , string
   , unlines
   , unwords
-  , singleton        -- singleton :: Monad m => Char -> ByteStream m ()
-  , fromChunks       -- fromChunks :: Monad m => Stream (Of ByteString) m r -> ByteStream m r
-  , fromLazy         -- fromLazy :: Monad m => ByteString -> ByteStream m ()
-  , fromStrict       -- fromStrict :: ByteString -> ByteStream m ()
-  , toChunks         -- toChunks :: Monad m => ByteStream m r -> Stream (Of ByteString) m r
-  , toLazy           -- toLazy :: Monad m => ByteStream m () -> m ByteString
+  , singleton
+  , fromChunks
+  , fromLazy
+  , fromStrict
+  , toChunks
+  , toLazy
   , toLazy_
-  , toStrict         -- toStrict :: Monad m => ByteStream m () -> m ByteString
+  , toStrict
   , toStrict_
   , effects
   , copy
@@ -47,72 +47,74 @@ module Streaming.ByteString.Char8
   , mwrap
 
     -- * Transforming ByteStreams
-  , map              -- map :: Monad m => (Char -> Char) -> ByteStream m r -> ByteStream m r
-  , intercalate      -- intercalate :: Monad m => ByteStream m () -> Stream (ByteStream m) m r -> ByteStream m r
-  , intersperse      -- intersperse :: Monad m => Char -> ByteStream m r -> ByteStream m r
+  , map
+  , intercalate
+  , intersperse
 
     -- * Basic interface
-  , cons             -- cons :: Monad m => Char -> ByteStream m r -> ByteStream m r
-  , cons'            -- cons' :: Char -> ByteStream m r -> ByteStream m r
+  , cons
+  , cons'
   , snoc
-  , append           -- append :: Monad m => ByteStream m r -> ByteStream m s -> ByteStream m s
-  , filter           -- filter :: (Char -> Bool) -> ByteStream m r -> ByteStream m r
-  , head             -- head :: Monad m => ByteStream m r -> m Char
-  , head_            -- head' :: Monad m => ByteStream m r -> m (Of Char r)
-  , last             -- last :: Monad m => ByteStream m r -> m Char
-  , last_            -- last' :: Monad m => ByteStream m r -> m (Of Char r)
-  , null             -- null :: Monad m => ByteStream m r -> m Bool
+  , append
+  , filter
+  , head
+  , head_
+  , last
+  , last_
+  , null
   , null_
+  , nulls
   , testNull
-  , nulls            -- null' :: Monad m => ByteStream m r -> m (Of Bool r)
-  , uncons           -- uncons :: Monad m => ByteStream m r -> m (Either r (Char, ByteStream m r))
+  , uncons
   , nextChar
   , skipSomeWS
 
     -- * Substrings
     -- ** Breaking strings
-  , break            -- break :: Monad m => (Char -> Bool) -> ByteStream m r -> ByteStream m (ByteStream m r)
-  , drop             -- drop :: Monad m => GHC.Int.Int64 -> ByteStream m r -> ByteStream m r
+  , break
+  , drop
   , dropWhile
-  , group            -- group :: Monad m => ByteStream m r -> Stream (ByteStream m) m r
+  , group
   , groupBy
-  , span             -- span :: Monad m => (Char -> Bool) -> ByteStream m r -> ByteStream m (ByteStream m r)
-  , splitAt          -- splitAt :: Monad m => GHC.Int.Int64 -> ByteStream m r -> ByteStream m (ByteStream m r)
-  , splitWith        -- splitWith :: Monad m => (Char -> Bool) -> ByteStream m r -> Stream (ByteStream m) m r
-  , take             -- take :: Monad m => GHC.Int.Int64 -> ByteStream m r -> ByteStream m ()
-  , takeWhile        -- takeWhile :: (Char -> Bool) -> ByteStream m r -> ByteStream m ()
+  , span
+  , splitAt
+  , splitWith
+  , take
+  , takeWhile
 
     -- ** Breaking into many substrings
-  , split            -- split :: Monad m => Char -> ByteStream m r -> Stream (ByteStream m) m r
+  , split
   , lines
-  , words
   , lineSplit
-  , denull
+  , words
 
     -- ** Special folds
-  , concat          -- concat :: Monad m => Stream (ByteStream m) m r -> ByteStream m r
+  , concat
+  , denull
 
     -- * Builders
   , toStreamingByteString
+
   , toStreamingByteStringWith
+
   , toBuilder
   , concatBuilders
 
     -- * Building ByteStreams
     -- ** Infinite ByteStreams
-  , repeat           -- repeat :: Char -> ByteStream m ()
-  , iterate          -- iterate :: (Char -> Char) -> Char -> ByteStream m ()
-  , cycle            -- cycle :: Monad m => ByteStream m r -> ByteStream m s
+  , repeat
+  , iterate
+  , cycle
 
     -- ** Unfolding ByteStreams
-  , unfoldr          -- unfoldr :: (a -> Maybe (Char, a)) -> a -> ByteStream m ()
-  , unfoldM          -- unfold  :: (a -> Either r (Char, a)) -> a -> ByteStream m r
+  , unfoldr
+  , unfoldM
   , reread
 
     -- *  Folds, including support for `Control.Foldl`
---    , foldr            -- foldr :: Monad m => (Char -> a -> a) -> a -> ByteStream m () -> m a
-  , fold             -- fold :: Monad m => (x -> Char -> x) -> x -> (x -> b) -> ByteStream m () -> m b
-  , fold_            -- fold' :: Monad m => (x -> Char -> x) -> x -> (x -> b) -> ByteStream m r -> m (b, r)
+    -- , foldr
+  , fold
+  , fold_
   , length
   , length_
   , count
@@ -121,29 +123,29 @@ module Streaming.ByteString.Char8
 
     -- * I\/O with 'ByteStream's
     -- ** Standard input and output
-  , getContents      -- getContents :: ByteStream IO ()
-  , stdin            -- stdin :: ByteStream IO ()
-  , stdout           -- stdout :: ByteStream IO r -> IO r
-  , interact         -- interact :: (ByteStream IO () -> ByteStream IO r) -> IO r
+  , getContents
+  , stdin
+  , stdout
+  , interact
   , putStr
   , putStrLn
 
     -- ** Files
-  , readFile         -- readFile :: FilePath -> ByteStream IO ()
-  , writeFile        -- writeFile :: FilePath -> ByteStream IO r -> IO r
-  , appendFile       -- appendFile :: FilePath -> ByteStream IO r -> IO r
+  , readFile
+  , writeFile
+  , appendFile
 
     -- ** I\/O with Handles
-  , fromHandle       -- fromHandle :: Handle -> ByteStream IO ()
-  , toHandle         -- toHandle :: Handle -> ByteStream IO r -> IO r
-  , hGet             -- hGet :: Handle -> Int -> ByteStream IO ()
-  , hGetContents     -- hGetContents :: Handle -> ByteStream IO ()
-  , hGetContentsN    -- hGetContentsN :: Int -> Handle -> ByteStream IO ()
-  , hGetN            -- hGetN :: Int -> Handle -> Int -> ByteStream IO ()
-  , hGetNonBlocking  -- hGetNonBlocking :: Handle -> Int -> ByteStream IO ()
-  , hGetNonBlockingN -- hGetNonBlockingN :: Int -> Handle -> Int -> ByteStream IO ()
-  , hPut             -- hPut :: Handle -> ByteStream IO r -> IO r
---    , hPutNonBlocking  -- hPutNonBlocking :: Handle -> ByteStream IO r -> ByteStream IO r
+  , fromHandle
+  , toHandle
+  , hGet
+  , hGetContents
+  , hGetContentsN
+  , hGetN
+  , hGetNonBlocking
+  , hGetNonBlockingN
+  , hPut
+    -- , hPutNonBlocking
 
     -- * Simple chunkwise operations
   , unconsChunk
@@ -158,10 +160,10 @@ module Streaming.ByteString.Char8
   , chunkMapM_
 
     -- * Etc.
---    , zipWithStream    -- zipWithStream :: Monad m => (forall x. a -> ByteStream m x -> ByteStream m x) -> [a] -> Stream (ByteStream m) m r -> Stream (ByteStream m) m r
-  , distribute      -- distribute :: ByteStream (t m) a -> t (ByteStream m) a
-  , materialize
   , dematerialize
+  , materialize
+  , distribute
+  , zipWithStream
   ) where
 
 import           Prelude hiding
@@ -194,7 +196,7 @@ import           Streaming.ByteString
     length_, nextChunk, null, null_, nulls, readFile, splitAt, stdin, stdout,
     take, testNull, toBuilder, toChunks, toHandle, toLazy, toLazy_,
     toStreamingByteString, toStreamingByteStringWith, toStrict, toStrict_,
-    unconsChunk, writeFile)
+    unconsChunk, writeFile, zipWithStream)
 
 import           Data.Word (Word8)
 import           Foreign.ForeignPtr (withForeignPtr)
@@ -203,7 +205,7 @@ import           Foreign.Storable
 import qualified System.IO as IO
 
 -- | Given a stream of bytes, produce a vanilla `Stream` of characters.
-unpack ::  Monad m => ByteStream m r ->  Stream (Of Char) m r
+unpack :: Monad m => ByteStream m r -> Stream (Of Char) m r
 unpack bs = case bs of
     Empty r    -> Return r
     Go m       -> Effect (fmap unpack m)
@@ -514,17 +516,13 @@ lines text0 = loop1 text0
 --  the \"lines\" had embedded newlines.
 --
 --  * @'unlines' . 'lines'@ will replace @\\r\\n@ with @\\n@.
-unlines :: Monad m => Stream (ByteStream m) m r ->  ByteStream m r
+unlines :: Monad m => Stream (ByteStream m) m r -> ByteStream m r
 unlines = loop where
   loop str =  case str of
     Return r -> Empty r
     Step bstr   -> do
       st <- bstr
-      let bs = unlines st
-      case bs of
-        Chunk "" (Empty r)   -> Empty r
-        Chunk "\n" (Empty _) -> bs
-        _                    -> cons' '\n' bs
+      cons' '\n' $ unlines st
     Effect m  -> Go (fmap unlines m)
 {-# INLINABLE unlines #-}
 

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -71,6 +71,7 @@ library
     , bytestring
     , deepseq
     , exceptions
+    , ghc-prim           >=0.4     && <0.8
     , mmorph             >=1.0     && <1.2
     , mtl                >=2.1     && <2.3
     , resourcet


### PR DESCRIPTION
- Add missing signature comments to export list, either they should all be
  present (or else perhaps none?)
- More performant rewrite of `denull`.  Less abstract machinery.
- Fix intersperse implementation to handle empty chunks.
- Fix intercalate implementation to not insert anything between
  the final substream and the outer stream end.
- Import 'SPEC' from GHC.Types, as of 9.0, GHC.Exts no longer
  exports `SpecConstrAnnotation`.