### PR TITLE
Bugfix, readInt fails to detect x-chunk overflow

### DIFF
--- a/lib/Streaming/ByteString/Char8.hs
+++ b/lib/Streaming/ByteString/Char8.hs
@@ -795,9 +795,13 @@ readInt = start
             Chunk c cs
                 | !l <- B.length c
                 , l > 0 -> case accumWord acc c of
-                     (0, !_, !_)
+                     (0, !_, !inrange)
+                         | inrange
                            -- no more digits found
                            -> result nbytes acc str
+                         | otherwise
+                           -- Overlow on first digit of chunk
+                           -> overflow nbytes acc str
                      (!n, !a, !inrange)
                          | False <- inrange
                            -- result out of 'Int' range

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -314,6 +314,19 @@ readIntCases = do
        $ addEffect cnt
        $ QI.Empty 16
   check cnt res Nothing (smin10 :> 16)
+  -- maxBound with cross-chunk overflow
+  IOR.writeIORef cnt 4
+  res <- readIntSkip
+       $ QI.Chunk " \t\n\v\f\r\xa0"
+       $ addEffect cnt
+       $ QI.Chunk (B.take 4 smax)
+       $ addEffect cnt
+       $ QI.Chunk (B.drop 4 smax)
+       $ addEffect cnt
+       $ QI.Chunk "00"
+       $ addEffect cnt
+       $ QI.Empty 17
+  check cnt res Nothing (smax `B.append` "00" :> 17)
   where
     -- Count down to zero from initial value
     readIntSkip = Q8.readInt . Q8.skipSomeWS


### PR DESCRIPTION
When the digit that causes overflow is the first digit of the next chunk,
readInt was failing to detect overflow and behaved as though no new digit
was found, returning the number accumulated so far.

This is now fixed, and a regression test added.