### PR TITLE
Use faster unsafeWithForeignPtr for GHC 9.0+

### DIFF
--- a/lib/Streaming/ByteString.hs
+++ b/lib/Streaming/ByteString.hs
@@ -209,7 +209,6 @@ import           Control.Monad.Trans.Resource
 import           Data.Int (Int64)
 import qualified Data.List as L
 import           Data.Word (Word8)
-import           Foreign.ForeignPtr (withForeignPtr)
 import           Foreign.Ptr
 import           Foreign.Storable
 import           System.IO (Handle, IOMode(..), hClose, openBinaryFile)
@@ -659,7 +658,7 @@ intersperse w (Chunk c cs) | B.null c = intersperse w cs
                                  (dematerialize cs Empty (Chunk . intersperse') Go)
   where intersperse' :: P.ByteString -> P.ByteString
         intersperse' (B.PS fp o l)
-          | l > 0 = B.unsafeCreate (2*l) $ \p' -> withForeignPtr fp $ \p -> do
+          | l > 0 = B.unsafeCreate (2*l) $ \p' -> unsafeWithForeignPtr fp $ \p -> do
               poke p' w
               B.c_intersperse (p' `plusPtr` 1) (p `plusPtr` o) (fromIntegral l) w
           | otherwise = B.empty

--- a/lib/Streaming/ByteString/Char8.hs
+++ b/lib/Streaming/ByteString/Char8.hs
@@ -201,7 +201,6 @@ import           Streaming.ByteString
 
 import           Data.Bits ((.&.))
 import           Data.Word (Word8)
-import           Foreign.ForeignPtr (withForeignPtr)
 import           Foreign.Ptr
 import           Foreign.Storable
 import qualified System.IO as IO
@@ -222,7 +221,7 @@ unpack bs = case bs of
 
   unpackAppendCharsStrict :: B.ByteString -> Stream (Of Char) m r -> Stream (Of Char) m r
   unpackAppendCharsStrict (B.PS fp off len) xs =
-    B.accursedUnutterablePerformIO $ withForeignPtr fp $ \base -> do
+    B.accursedUnutterablePerformIO $ unsafeWithForeignPtr fp $ \base -> do
          loop (base `plusPtr` (off-1)) (base `plusPtr` (off-1+len)) xs
      where
        loop !sentinal !p acc
@@ -628,7 +627,7 @@ nthNewLine :: B.ByteString   -- input chunk
            -> Int            -- remaining number of newlines wanted
            -> Either Int Int -- Left count, else Right length
 nthNewLine (B.PS fp off len) targetLines =
-    B.accursedUnutterablePerformIO $ withForeignPtr fp $ \base ->
+    B.accursedUnutterablePerformIO $ unsafeWithForeignPtr fp $ \base ->
     loop (base `plusPtr` off) targetLines 0 len
   where
     loop :: Ptr Word8 -> Int -> Int -> Int -> IO (Either Int Int)
@@ -823,7 +822,7 @@ readInt = start
         -- the provided digits (end of input or non-digit encountered).
         accumWord acc (B.PS fp off len) =
             B.accursedUnutterablePerformIO $ do
-                withForeignPtr fp $ \p -> do
+                unsafeWithForeignPtr fp $ \p -> do
                     let ptr = p `plusPtr` off
                         end = ptr `plusPtr` len
                     x@(!_, !_, !_) <- if positive


### PR DESCRIPTION
With GHC 9.0 `withForeignPtr` was made safe for actions that might loop forever
or always throw an exception.  This safety comes at the cost of performance,
the result is always allocated, which is not ideal for primitive byte-level
memory operations.

A new `unsafeWithForeignPtr` is added that provides the old non-allocating
behaviour when the action is sure to terminate.  With GHC 9.0 and later,
we use this function to loop over the content of ByteStream chunks.