### PR TITLE
Generalise `Streaming.ByteString.for` so that it's actually usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+#### Changed
+
+- Changed `for`'s callback to return `ByteStream m x`, to clarify that
+  it is not used.
+
 ## 0.2.3 (2022-08-18)
 
 #### Added

--- a/lib/Streaming/ByteString.hs
+++ b/lib/Streaming/ByteString.hs
@@ -643,8 +643,11 @@ map f z = dematerialize z Empty (Chunk . B.map f) Go
 -- | @'for' xs f@ applies @f@ to each chunk in the stream, and
 -- concatenates the resulting streams.
 --
+-- Generalised in 0.2.4 to match @streaming@: the callback's (ignored)
+-- return value can be of any type.
+--
 -- @since 0.2.3
-for :: Monad m => ByteStream m r -> (P.ByteString -> ByteStream m r) -> ByteStream m r
+for :: Monad m => ByteStream m r -> (P.ByteString -> ByteStream m x) -> ByteStream m r
 for stream f = case stream of
   Empty r -> Empty r
   Chunk bs bss -> f bs *> for bss f


### PR DESCRIPTION
Sorry about this, but the type of `for` is insufficiently general. This PR makes it not care about the ByteStream return type from the callback, which makes it actually useful for return types other than `()`.