### PR TITLE
GHC 9.4.4 compat and try to also test 9.2

### DIFF
--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -8,12 +8,14 @@ on:
 jobs:
   build:
     name: CI
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         resolver:
           [
+            "nightly-2023-01-03",
+            "lts-20.5",
             "lts-19.7",
             "lts-18.28",
             "lts-16.31",
@@ -23,20 +25,62 @@ jobs:
             "lts-9.21",
           ]
         include:
+          - resolver: "nightly-2023-01-03"
+            os: ubuntu-latest
+            ghc: "9.4.4"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-20.5"
+            os: ubuntu-latest
+            ghc: "9.2.5"
+            cabal: latest
+            stack: latest
           - resolver: "lts-19.7"
+            os: ubuntu-latest
             ghc: "9.0.2"
+            cabal: latest
+            stack: latest
           - resolver: "lts-18.28"
+            os: ubuntu-latest
             ghc: "8.10.7"
+            cabal: latest
+            stack: latest
           - resolver: "lts-16.31"
+            os: ubuntu-latest
             ghc: "8.8.4"
+            cabal: latest
+            stack: latest
           - resolver: "lts-14.27"
+            os: ubuntu-latest
             ghc: "8.6.5"
+            cabal: latest
+            stack: latest
           - resolver: "lts-12.26"
+            os: ubuntu-latest
             ghc: "8.4.4"
+            cabal: latest
+            stack: latest
           - resolver: "lts-11.22"
+            os: ubuntu-latest
             ghc: "8.2.2"
+            cabal: latest
+            stack: latest
           - resolver: "lts-9.21"
+            os: ubuntu-latest
             ghc: "8.0.2"
+            cabal: latest
+            stack: latest
+          #
+          # The stock 7.10.3 compiler runs into compat issues with recent
+          # linkers that enable -fPIE by default.  Apparently the hvr ppa
+          # GHC has backported work-arounds for this, so perhaps possible
+          # to install it instead, but for now just punting on 7.10 tests
+          #
+          #   - resolver: "lts-6.35"
+          #     os: ubuntu-18.04
+          #     ghc: "7.10.3"
+          #     cabal: 2.2
+          #     stack: 1.6
 
     steps:
       - name: Setup GHC
@@ -44,7 +88,8 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           enable-stack: true
-          stack-version: "latest"
+          stack-version: ${{ matrix.stack }}
+          cabal-version: ${{ matrix.cabal }}
 
       - name: Clone project
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.5 (2023-01-05)
+
+- Tightened PVP version bounds, for GHC 7.10 through to GHC 9.4.4.
+  CI tests for 7.10 not presently implemented.
+
 ## 0.2.4 (2022-08-26)
 
 #### Changed

--- a/lib/Streaming/ByteString/Internal.hs
+++ b/lib/Streaming/ByteString/Internal.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UnboxedTuples         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE UnliftedFFITypes      #-}

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -34,14 +34,15 @@ bug-reports:
   https://github.com/haskell-streaming/streaming-bytestring/issues
 
 tested-with:
-  GHC ==7.10.3
-   || ==8.0.2
+  GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
    || ==8.6.5
    || ==8.8.4
    || ==8.10.3
    || ==9.0.2
+   || ==9.2.5
+   || ==9.4.4
 
 source-repository head
   type:     git
@@ -69,31 +70,20 @@ library
 
   build-depends:
       base               >=4.8     && <5.0
-    , bytestring
-    , deepseq
-    , exceptions
-    , ghc-prim           >=0.4     && <0.9
+    , bytestring         >=0.10.4  && <0.12
+    , deepseq            >=1.4     && <1.5
+    , exceptions         >=0.8     && <0.11
+    , ghc-prim           >=0.4     && <0.10
     , mmorph             >=1.0     && <1.3
-    , mtl                >=2.1     && <2.3
-    , resourcet
+    , mtl                >=2.2     && <2.4
+    , resourcet          >=1.1     && <1.4
     , streaming          >=0.1.4.0 && <0.3
-    , transformers       >=0.3     && <0.6
-    , transformers-base
-
-  if impl(ghc <7.8)
-    build-depends:
-        bytestring          >=0 && <0.10.4.0
-      , bytestring-builder
-
-  else
-    if impl(ghc <8.0)
-      build-depends: bytestring >=0.10.4 && <0.11
-
-    else
-      build-depends: bytestring >=0.10.4 && <0.12
+    , transformers       >=0.4     && <0.7
+    , transformers-base  >=0.4     && <0.5
 
   if impl(ghc <8.0)
-    build-depends: semigroups
+    build-depends:
+      semigroups         >=0.18    && <0.19
 
 test-suite test
   default-language: Haskell2010
@@ -101,13 +91,13 @@ test-suite test
   hs-source-dirs:   tests
   main-is:          Test.hs
   build-depends:
-      base                  >=4        && <5
-    , bytestring
-    , resourcet             >=1.1
+      base                  >=4.8     && <5
+    , bytestring            >=0.10.4  && <0.12
+    , resourcet             >=1.1     && <1.4
     , smallcheck            >=1.1.1
-    , streaming
+    , streaming             >=0.1.4.0 && <0.3
     , streaming-bytestring
     , tasty                 >=0.11.0.4
     , tasty-hunit           >=0.9
     , tasty-smallcheck      >=0.8.1
-    , transformers
+    , transformers          >=0.3     && <0.7


### PR DESCRIPTION
- Minor tweaks to PVP bounds for 9.4.4, but also test 9.2
- Set upper bounds on all dependencies.
- CI for 7.10.3 left as exercise for someone more expert in Github CI.
- Added TypeOperators to internal module per GHC 9.4 warning that `~` will need it in a future GHC.
