### PR TITLE
Enable GHC 9.6 support

### DIFF
--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -73,7 +73,7 @@ library
     , bytestring         >=0.10.4  && <0.12
     , deepseq            >=1.4     && <1.5
     , exceptions         >=0.8     && <0.11
-    , ghc-prim           >=0.4     && <0.10
+    , ghc-prim           >=0.4     && <0.11
     , mmorph             >=1.0     && <1.3
     , mtl                >=2.2     && <2.4
     , resourcet          >=1.1     && <1.4


### PR DESCRIPTION
Bumps upper bound for ghc-prim in GHC 9.6.2.