### PR TITLE
Make it build with ghc-9.8 (deps only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 0.3.2 (2023-11-17)
+
+#### Changed
+
+- Ensure support for GHC 9.8.
+
 ## 0.3.1 (2023-06-28)
 
 #### Changed

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -71,10 +71,10 @@ library
 
   build-depends:
       base               >=4.9     && <5.0
-    , bytestring         >=0.10.4  && <0.12
-    , deepseq            >=1.4     && <1.5
+    , bytestring         >=0.10.4  && <0.13
+    , deepseq            >=1.4     && <1.6
     , exceptions         >=0.8     && <0.11
-    , ghc-prim           >=0.4     && <0.11
+    , ghc-prim           >=0.4     && <0.12
     , mmorph             >=1.0     && <1.3
     , mtl                >=2.2     && <2.4
     , resourcet          >=1.1     && <1.4
@@ -93,7 +93,7 @@ test-suite test
   main-is:          Test.hs
   build-depends:
       base                  >=4.9     && <5
-    , bytestring            >=0.10.4  && <0.12
+    , bytestring            >=0.10.4  && <0.13
     , resourcet             >=1.1     && <1.4
     , smallcheck            >=1.1.1
     , streaming             >=0.1.4.0 && <0.3

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               streaming-bytestring
-version:            0.3.1
+version:            0.3.2
 synopsis:           Fast, effectful byte streams.
 description:
   This library enables fast and safe streaming of byte data, in either @Word8@ or
@@ -41,9 +41,9 @@ tested-with:
    || ==8.8.4
    || ==8.10.3
    || ==9.0.2
-   || ==9.2.5
-   || ==9.4.5
-   || ==9.6.2
+   || ==9.2.7
+   || ==9.4.7
+   || ==9.6.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
Since support only requires a Hackage metadata edit, I would greatly appreciate if that was done.