### PR TITLE
Bump ghc-prim upper bounds 

### DIFF
--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         resolver:
           [
+            "lts-23.7",
             "lts-22.36",
             "lts-21.25",
             "lts-20.26",
@@ -26,34 +27,47 @@ jobs:
             "lts-9.21",
           ]
         include:
+          - resolver: "lts-23.7"
+            ghc: "9.8.4"
+            stack-version: latest
           - resolver: "lts-22.36"
             ghc: "9.6.6"
+            stack-version: latest
           - resolver: "lts-21.25"
             ghc: "9.4.8"
+            stack-version: latest
           - resolver: "lts-20.26"
             ghc: "9.2.5"
+            stack-version: latest
           - resolver: "lts-19.33"
             ghc: "9.0.2"
+            stack-version: latest
           - resolver: "lts-18.28"
             ghc: "8.10.7"
+            stack-version: latest
           - resolver: "lts-16.31"
             ghc: "8.8.4"
+            stack-version: latest
           - resolver: "lts-14.27"
             ghc: "8.6.5"
+            stack-version: latest
           - resolver: "lts-12.26"
             ghc: "8.4.4"
+            stack-version: latest
           - resolver: "lts-11.22"
             ghc: "8.2.2"
+            stack-version: "2.15.5"
           - resolver: "lts-9.21"
             ghc: "8.0.2"
+            stack-version: "2.15.5"
 
     steps:
       - name: Setup GHC
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           enable-stack: true
-          stack-version: "latest"
+          stack-version:  ${{ matrix.stack-version }}
 
       - name: Clone project
         uses: actions/checkout@v4

--- a/streaming-bytestring.cabal
+++ b/streaming-bytestring.cabal
@@ -74,7 +74,7 @@ library
     , bytestring         >=0.10.4  && <0.13
     , deepseq            >=1.4     && <1.6
     , exceptions         >=0.8     && <0.11
-    , ghc-prim           >=0.4     && <0.12
+    , ghc-prim           >=0.4     && <0.14
     , mmorph             >=1.0     && <1.3
     , mtl                >=2.2     && <2.4
     , resourcet          >=1.1     && <1.4


### PR DESCRIPTION
Currently this package won't install with ghc 9.12.1 because of `ghc-prim` bounds.

 * 3a76b7bcbcf67db1aacc8fbd3b6bdd8a50a398e6 does the bare minimum change
 
 The other two commits are fussing with CI. I don't use stack but it looks like 9.12 and 9.10 aren't available in a released LTS.
 So CI won't test either version. 